### PR TITLE
PIA-XXXX: Bump version to `4.0.4 (667)`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,10 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-val googleAppVersionCode = 666
+val googleAppVersionCode = 667
 val amazonAppVersionCode = googleAppVersionCode.plus(10000)
 val noInAppVersionCode = googleAppVersionCode.plus(10000)
-val appVersionName = "4.0.3"
+val appVersionName = "4.0.4"
 
 android {
     namespace = "com.kape.vpn"


### PR DESCRIPTION
## Summary

As per title. It bumps de version name and code to `4.0.4` and `667` respectively.

## Sanity Tests

N/A