### PR TITLE
PIA-XXXX: Update automatic and optimal to consider auto and exclude geo servers

### DIFF
--- a/core/regions/src/main/java/com/kape/vpnregions/utils/RegionListProvider.kt
+++ b/core/regions/src/main/java/com/kape/vpnregions/utils/RegionListProvider.kt
@@ -24,10 +24,11 @@ class RegionListProvider(
     }
 
     fun getOptimalServer(): VpnServer {
-        return if (_servers.value.none { it.latency != null }) {
-            return getAutoServer()
+        val optimalServerOptions = _servers.value.filter { it.autoRegion && it.isGeo.not() }
+        return if (optimalServerOptions.none { it.latency != null }) {
+            optimalServerOptions.random()
         } else {
-            _servers.value.sortedBy { it.latency?.toInt() }.first()
+            optimalServerOptions.sortedBy { it.latency?.toInt() }.first()
         }
     }
 
@@ -62,9 +63,5 @@ class RegionListProvider(
                     emit(updatedServers)
                 }
         }
-    }
-
-    private fun getAutoServer(): VpnServer {
-        return _servers.value.filter { it.autoRegion && it.isGeo.not() }.random()
     }
 }


### PR DESCRIPTION
## Summary

As per title.

## Sanity Tests

- [x] Connect Desktop to Singapore. Open mobile. Pull down to refresh. Confirm the top are geo servers. Tap optimal. Confirm we connect to the first non-geo server.
- [x] Connect Desktop to Stockholm. Open mobile. Pull down to refresh. Confirm streaming is the first one. Tap optima. Confirm we skip the streaming server as it's not an auto server.