### PR TITLE
PIA-1890: Fix TV clear search button

### DIFF
--- a/capabilities/ui/src/main/java/com/kape/ui/tv/elements/Search.kt
+++ b/capabilities/ui/src/main/java/com/kape/ui/tv/elements/Search.kt
@@ -1,0 +1,67 @@
+package com.kape.ui.tv.elements
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.kape.ui.R
+import com.kape.ui.mobile.text.SearchInputLabelText
+import com.kape.ui.utils.LocalColors
+
+@Composable
+fun Search(modifier: Modifier, onTextChanged: (text: String) -> Unit) {
+    val query = remember { mutableStateOf("") }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.weight(1.0f),
+            value = query.value,
+            onValueChange = {
+                query.value = it
+                onTextChanged(it)
+            },
+            placeholder = {
+                SearchInputLabelText(content = stringResource(id = R.string.search))
+            },
+            shape = RoundedCornerShape(12.dp),
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_search),
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                )
+            },
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = LocalColors.current.surfaceVariant,
+                unfocusedContainerColor = LocalColors.current.surfaceVariant,
+                disabledContainerColor = LocalColors.current.surfaceVariant,
+                focusedBorderColor = LocalColors.current.onSurfaceVariant,
+                errorBorderColor = LocalColors.current.error,
+                cursorColor = LocalColors.current.onSurface,
+            ),
+            singleLine = true,
+        )
+        RoundIconButton(
+            modifier = Modifier.padding(start = 16.dp),
+            painterId = R.drawable.ic_close,
+            onClick = {
+                query.value = ""
+                onTextChanged("")
+            },
+        )
+    }
+}

--- a/features/vpnregionselection/src/main/java/com/kape/vpnregionselection/ui/tv/TvVpnRegionSelectionScreen.kt
+++ b/features/vpnregionselection/src/main/java/com/kape/vpnregionselection/ui/tv/TvVpnRegionSelectionScreen.kt
@@ -42,11 +42,11 @@ import com.kape.appbar.view.tv.TvHomeHeaderItem
 import com.kape.regions.data.ServerData
 import com.kape.ui.R
 import com.kape.ui.mobile.elements.Screen
-import com.kape.ui.mobile.elements.Search
 import com.kape.ui.theme.statusBarConnected
 import com.kape.ui.theme.statusBarConnecting
 import com.kape.ui.theme.statusBarDefault
 import com.kape.ui.theme.statusBarError
+import com.kape.ui.tv.elements.Search
 import com.kape.ui.tv.text.RegionSelectionGridSectionText
 import com.kape.ui.utils.LocalColors
 import com.kape.vpnconnect.utils.ConnectionManager
@@ -182,7 +182,7 @@ fun TvVpnRegionSelectionScreen() = Screen {
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp, vertical = 8.dp),
                         ) {
-                            viewModel.filterByName(it, isSearchEnabled)
+                            viewModel.filterByName(it)
                         }
                     }
                     if (isFavoriteSelected.value) {

--- a/features/vpnregionselection/src/main/java/com/kape/vpnregionselection/ui/vm/VpnRegionSelectionViewModel.kt
+++ b/features/vpnregionselection/src/main/java/com/kape/vpnregionselection/ui/vm/VpnRegionSelectionViewModel.kt
@@ -67,16 +67,17 @@ class VpnRegionSelectionViewModel(
         updateVpnServers()
     }
 
-    fun filterByName(value: String, isSearchEnabled: MutableState<Boolean>) =
+    fun filterByName(value: String, isSearchEnabled: MutableState<Boolean>? = null) =
         viewModelScope.launch {
             if (value.isNotEmpty()) {
-                isSearchEnabled.value = true
+                isSearchEnabled?.value = true
                 sorted.value = servers.value.filter {
                     it.type is ItemType.Content && it.type.server.name.lowercase()
                         .contains(value.lowercase())
                 }
             } else {
-                isSearchEnabled.value = false
+                sorted.value = emptyList()
+                isSearchEnabled?.value = false
             }
         }
 


### PR DESCRIPTION
## Summary

The clear button is not easily tappable, and it’s hidden by default. Even when the user manages to focus on it and tap, the search field disappears as that’s borrowed logic from the mobile.

- Create TV specific Search element showing the clear button always.
- Make the hiding on clear optional so that we don't hide it on TV.
- Clear sorted list of servers when the received filter is an empty string.

## Sanity Tests

- [x] Go to search. Confirm the text field and clear button visible.
- [x] After the above. Type something. Confirm the list of servers updates accordingly.
- [x] After the above. Tap on the clear button. Confirm that searched text is removed, and the list of servers is updated to show everything.