### PR TITLE
PIA-XXXX: Bump version to `4.0.6 (669)`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,10 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-val googleAppVersionCode = 668
+val googleAppVersionCode = 669
 val amazonAppVersionCode = googleAppVersionCode.plus(10000)
 val noInAppVersionCode = googleAppVersionCode.plus(10000)
-val appVersionName = "4.0.5"
+val appVersionName = "4.0.6"
 
 android {
     namespace = "com.kape.vpn"


### PR DESCRIPTION
## Summary

As per title. It bumps de version name and code to `4.0.6` and `669` respectively.

## Sanity Tests

N/A