### PR TITLE
PIA-1887: Introduce DIP signup logic checking for an active playstore subscription

### DIFF
--- a/core/payments/src/amazon/java/com/kape/payments/ui/PaymentProviderImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/ui/PaymentProviderImpl.kt
@@ -16,7 +16,10 @@ import com.kape.payments.utils.PurchaseHistoryState
 import com.kape.payments.utils.PurchaseState
 import com.kape.payments.utils.monthlySubscription
 import com.kape.payments.utils.yearlySubscription
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 
 private const val M1 = "PIA-M1"
 private const val Y1 = "PIA-Y1"
@@ -113,6 +116,11 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
 
     override fun getPurchaseHistory() {
         // no-op
+    }
+
+    override fun hasActiveSubscription(): Flow<Boolean> = callbackFlow {
+        trySend(false)
+        awaitClose { channel.close() }
     }
 
     override fun isClientRegistered(): Boolean {

--- a/core/payments/src/main/java/com/kape/payments/ui/PaymentProvider.kt
+++ b/core/payments/src/main/java/com/kape/payments/ui/PaymentProvider.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.kape.payments.data.Subscription
 import com.kape.payments.utils.PurchaseHistoryState
 import com.kape.payments.utils.PurchaseState
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 interface PaymentProvider {
@@ -25,6 +26,8 @@ interface PaymentProvider {
     fun getPurchaseUpdates()
 
     fun getPurchaseHistory()
+
+    fun hasActiveSubscription(): Flow<Boolean>
 
     fun isClientRegistered(): Boolean
 }

--- a/core/payments/src/noinapp/java/com/kape/payments/ui/PaymentProviderImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/ui/PaymentProviderImpl.kt
@@ -7,7 +7,10 @@ import com.kape.payments.utils.PurchaseHistoryState
 import com.kape.payments.utils.PurchaseState
 import com.kape.payments.utils.monthlySubscription
 import com.kape.payments.utils.yearlySubscription
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 
 class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Activity? = null) :
     PaymentProvider {
@@ -42,6 +45,11 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
 
     override fun getPurchaseHistory() {
         // no-op
+    }
+
+    override fun hasActiveSubscription(): Flow<Boolean> = callbackFlow {
+        trySend(false)
+        awaitClose { channel.close() }
     }
 
     override fun isClientRegistered(): Boolean {

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -61,7 +61,6 @@ fun SignupDedicatedIpCountryScreen() = Screen {
         appBarText(stringResource(id = R.string.dedicated_ip_title))
     }
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getActivePlaystoreSubscription()
         getSupportedDipCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -51,7 +51,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun SignupDedicatedIpScreen() = Screen {
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getActivePlaystoreSubscription()
+        hasActivePlaystoreSubscription()
         getSupportedDipCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
@@ -19,7 +19,6 @@ import com.kape.dedicatedip.utils.DedicatedIpStep
 import com.kape.dedicatedip.utils.DipApiResult
 import com.kape.dip.DipPrefs
 import com.kape.payments.ui.PaymentProvider
-import com.kape.payments.utils.PurchaseHistoryState
 import com.kape.router.Back
 import com.kape.router.Router
 import com.kape.utils.vpnserver.VpnServer
@@ -48,7 +47,7 @@ class DipViewModel(
 
     val dipList = mutableStateListOf<VpnServer>()
     val activationState = mutableStateOf<DipApiResult?>(null)
-    val hasAnActivePlaystoreSubscription = mutableStateOf(false)
+    val hasAnActivePlaystoreSubscription = mutableStateOf(true)
     val supportedDipCountriesList = mutableStateOf<SupportedCountries?>(null)
     val dipMonthlyPlan = mutableStateOf<DedicatedIpMonthlyPlan?>(null)
     val dipYearlyPlan = mutableStateOf<DedicatedIpYearlyPlan?>(null)
@@ -160,25 +159,10 @@ class DipViewModel(
         }
     }
 
-    fun getActivePlaystoreSubscription() {
-        viewModelScope.launch {
-            paymentProvider.purchaseHistoryState.collect {
-                when (it) {
-                    is PurchaseHistoryState.PurchaseHistorySuccess -> {
-                        hasAnActivePlaystoreSubscription.value = true
-                    }
-
-                    PurchaseHistoryState.Default -> {
-                        // no=op
-                    }
-
-                    PurchaseHistoryState.PurchaseHistoryFailed -> {
-                        hasAnActivePlaystoreSubscription.value = false
-                    }
-                }
-            }
+    fun hasActivePlaystoreSubscription() = viewModelScope.launch {
+        paymentProvider.hasActiveSubscription().collect {
+            hasAnActivePlaystoreSubscription.value = it
         }
-        paymentProvider.getPurchaseHistory()
     }
 
     fun showDedicatedIpSignupBanner() =


### PR DESCRIPTION
## Summary

It introduces the logic checking whether there is an active playstore subscription before showing the DIP signup flow.

## Sanity Tests

- [x] Open application. Purchase subscription. Go to DIP signup flow. Confirm it shows the mocked plans.
- [x] After the above. Cancel the subscription. Go to DIP signup flow. Confirm it shows the error stating there are no active playstore subscriptions.