### PR TITLE
PIA-1892: Show DIP Signup only on Google flavor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,6 +162,7 @@ dependencies {
     implementation(project(":capabilities:csi"))
     implementation(project(":capabilities:networkmanagement"))
     implementation(project(":capabilities:snooze"))
+    implementation(project(":capabilities:buildconfig"))
 
     implementation(project(":features:splash"))
     implementation(project(":features:tvwelcome"))

--- a/app/src/main/java/com/kape/vpn/App.kt
+++ b/app/src/main/java/com/kape/vpn/App.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.kape.about.di.aboutModule
 import com.kape.appbar.di.appBarModule
 import com.kape.automation.di.automationModule
+import com.kape.buildconfig.di.buildConfigModule
 import com.kape.connection.di.connectionModule
 import com.kape.csi.di.csiModule
 import com.kape.customization.di.customizationModule
@@ -68,6 +69,7 @@ class App : Application() {
                 add(vpnConnectModule(appModule))
                 add(appBarModule(appModule))
                 add(notificationModule)
+                add(buildConfigModule(BuildConfig.FLAVOR, BuildConfig.BUILD_TYPE))
                 add(paymentsModule(appModule))
                 add(loginModule(appModule))
                 add(permissionsModule(appModule))

--- a/capabilities/buildconfig/build.gradle.kts
+++ b/capabilities/buildconfig/build.gradle.kts
@@ -1,15 +1,13 @@
-import Dependencies.implementAccount
-import Dependencies.implementSerialization
+import Dependencies.implementKoin
 
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.jlleitschuh.gradle.ktlint")
-    id("kotlinx-serialization")
 }
 
 android {
-    namespace = "com.kape.dip.prefs"
+    namespace = "com.kape.buildconfig"
     compileSdk = 34
 
     defaultConfig {
@@ -20,15 +18,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-
     kotlinOptions {
         jvmTarget = "17"
     }
 }
 
 dependencies {
-    implementation(project(":core:utils"))
-    implementation(project(":capabilities:buildconfig"))
-    implementAccount()
-    implementSerialization()
+    implementKoin()
 }

--- a/capabilities/buildconfig/src/main/AndroidManifest.xml
+++ b/capabilities/buildconfig/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildConfigProvider.kt
+++ b/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildConfigProvider.kt
@@ -1,0 +1,35 @@
+package com.kape.buildconfig.data
+
+class BuildConfigProvider(
+    private val buildFlavor: String,
+    private val buildType: String,
+) {
+
+    private val flavor = when (buildFlavor) {
+        "google" -> BuildFlavor.GOOGLE
+        "amazon" -> BuildFlavor.AMAZON
+        "noinapp" -> BuildFlavor.WEB
+        else -> throw IllegalArgumentException("Unknown app flavor. Please update enum.")
+    }
+
+    private val type = when (buildType) {
+        "debug" -> BuildType.DEBUG
+        "release" -> BuildType.RELEASE
+        else -> throw IllegalArgumentException("Unknown app type. Please update enum.")
+    }
+
+    fun isGoogleFlavor() =
+        flavor == BuildFlavor.GOOGLE
+
+    fun isAmazonFlavor() =
+        flavor == BuildFlavor.AMAZON
+
+    fun isWebFlavor() =
+        flavor == BuildFlavor.WEB
+
+    fun isDebugType() =
+        type == BuildType.DEBUG
+
+    fun isReleaseType() =
+        type == BuildType.RELEASE
+}

--- a/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildFlavor.kt
+++ b/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildFlavor.kt
@@ -1,0 +1,7 @@
+package com.kape.buildconfig.data
+
+internal enum class BuildFlavor {
+    GOOGLE,
+    AMAZON,
+    WEB,
+}

--- a/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildType.kt
+++ b/capabilities/buildconfig/src/main/java/com/kape/buildconfig/data/BuildType.kt
@@ -1,0 +1,6 @@
+package com.kape.buildconfig.data
+
+internal enum class BuildType {
+    DEBUG,
+    RELEASE,
+}

--- a/capabilities/buildconfig/src/main/java/com/kape/buildconfig/di/BuildConfigModule.kt
+++ b/capabilities/buildconfig/src/main/java/com/kape/buildconfig/di/BuildConfigModule.kt
@@ -1,0 +1,8 @@
+package com.kape.buildconfig.di
+
+import com.kape.buildconfig.data.BuildConfigProvider
+import org.koin.dsl.module
+
+fun buildConfigModule(buildFlavor: String, buildType: String) = module {
+    single { BuildConfigProvider(buildFlavor, buildType) }
+}

--- a/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
@@ -1,6 +1,7 @@
 package com.kape.dip
 
 import android.content.Context
+import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.dip.data.DedicatedIpSignupPlans
 import com.kape.utils.Prefs
 import com.privateinternetaccess.account.model.response.DedicatedIPInformationResponse
@@ -13,7 +14,10 @@ private const val DIP_SIGNUP_HOME_BANNER_VISIBLE = "dip-signup-home-banner-visib
 private const val DIP_SIGNUP_PLANS = "dip-signup-plans"
 private const val DIP_SIGNUP_PURCHASED_TOKEN = "dip-signup-purchased-token"
 
-class DipPrefs(context: Context) : Prefs(context, "dip") {
+class DipPrefs(
+    context: Context,
+    private val buildConfigProvider: BuildConfigProvider,
+) : Prefs(context, "dip") {
 
     fun getDedicatedIps(): List<DedicatedIPInformationResponse.DedicatedIPInformation> {
         val dips = mutableListOf<DedicatedIPInformationResponse.DedicatedIPInformation>()
@@ -47,7 +51,11 @@ class DipPrefs(context: Context) : Prefs(context, "dip") {
         prefs.edit().remove(DIP_SIGNUP_PURCHASED_TOKEN).apply()
     }
 
-    fun isDipSignupEnabled() = prefs.getBoolean(DIP_SIGNUP_ENABLED, false)
+    fun isDipSignupEnabled() = if (buildConfigProvider.isGoogleFlavor()) {
+        prefs.getBoolean(DIP_SIGNUP_ENABLED, false)
+    } else {
+        false
+    }
 
     fun showDedicatedIpHomeBanner() = prefs.getBoolean(DIP_SIGNUP_HOME_BANNER_VISIBLE, false)
 

--- a/features/dedicatedip/build.gradle.kts
+++ b/features/dedicatedip/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(project(":core:localprefs:dip"))
     implementation(project(":features:appbar"))
     implementation(project(":capabilities:ui"))
+    implementation(project(":capabilities:buildconfig"))
     implementAccount()
     implementRegions()
     implementFeatureModule()

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
@@ -21,7 +21,7 @@ fun dedicatedIpModule(appModule: Module) = module {
 }
 
 val localDipModule = module {
-    single { DipPrefs(get()) }
+    single { DipPrefs(get(), get()) }
     single<DipDataSource> { DipDataSourceImpl(get(), get()) }
     single { DipSignupRepository(get(), get()) }
     single { ActivateDipUseCase(get()) }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,7 @@ include(":capabilities:csi")
 include(":capabilities:location")
 include(":capabilities:networkmanagement")
 include(":capabilities:snooze")
+include(":capabilities:buildconfig")
 
 include(":core")
 include(":core:router")


### PR DESCRIPTION
## Summary

- It introduces the `:capabilities:buildconfig` module for flavors and types.
- It enables DIP signup only on Google.

## Sanity Tests

- [x] Compile using the Google flavor. Confirm banner is visible on the home screen.
- [x] Compile using the Amazon flavor. Confirm banner is **not** visible on the home screen.
- [x] Compile using the Noinapp flavor. Confirm banner is **not** visible on the home screen.