### PR TITLE
PIA-1898: Fix meta IPs selection

### DIFF
--- a/app/src/main/java/com/kape/vpn/provider/MetaEndpointsProvider.kt
+++ b/app/src/main/java/com/kape/vpn/provider/MetaEndpointsProvider.kt
@@ -20,7 +20,7 @@ class MetaEndpointsProvider : KoinComponent {
         val selectedRegion = connectionPrefs.getSelectedVpnServer()
 
         // Get the list of known regions sorted by latency.
-        val sortedLatencyRegions = regionsListProvider.servers.value
+        val sortedLatencyRegions = regionsListProvider.servers.value.sortedBy { it.latency?.toInt() }
 
         // Filter out invalid latencies. e.g. nil, zero, etc.
         val regionsWithValidLatency = sortedLatencyRegions.filterNot {


### PR DESCRIPTION
## Summary

It fixes the meta endpoint provider as it did not take into account latencies when selecting the meta endpoints to use.

## Sanity Tests

- [x] Using custom logging. Install app. Login. Confirm endpoints are chosen randomly as there are no latencies available.
- [x] After the above. Go to the region list. Confirm latencies are present. Logout. Confirm endpoints are chosen based on latency.