### PR TITLE
PIA-1900: Update regions library to `1.7.0`

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -153,7 +153,7 @@ object Dependencies {
     }
 
     fun DependencyHandler.implementRegions() {
-        add(IMPLEMENTATION, "com.kape.android:regions-android:1.6.5")
+        add(IMPLEMENTATION, "com.kape.android:regions-android:1.7.0")
     }
 
     fun DependencyHandler.implementObfuscator() {

--- a/core/regions/src/test/java/com/kape/vpnregions/data/VpnRegionRepositoryTest.kt
+++ b/core/regions/src/test/java/com/kape/vpnregions/data/VpnRegionRepositoryTest.kt
@@ -99,7 +99,7 @@ class VpnRegionRepositoryTest : KoinTest {
             Arguments.of(null, emptyList<VpnServer>()),
         )
 
-        private val latencyInfo = RegionLowerLatencyInformation("id", "endpoint", 0)
+        private val latencyInfo = RegionLowerLatencyInformation("id", 0)
 
         @JvmStatic
         fun latencies() = Stream.of(


### PR DESCRIPTION
## Summary

It updates the regions library to `1.7.0` where we are no longer pinging all meta servers within a region, but rather one per region.

## Sanity Tests

- [x] Open the app. Go to the regions list. Pull down to refresh. Confirm list of servers and latencies are updated successfully.