### PR TITLE
PIA-1911: Add website build to release assets

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup jdk
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Make Gradle executable
         run: chmod +x ./gradlew
       - name: Build Release APK
@@ -31,5 +31,5 @@ jobs:
       - name: Releasing using Hub
         uses: kyze8439690/action-release-releaseapk@master
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
           APP_FOLDER: app

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Releasing using Hub
         uses: kyze8439690/action-release-releaseapk@master
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
           APP_FOLDER: app

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,35 @@
+name: Build & Publish FDroid APK
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  Gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: setup jdk
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+      - name: Build Release APK
+        run: ./gradlew assembleNoinappRelease
+      - name: Sign APK
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/apk/noinapp/release
+          signingKeyBase64: ${{ secrets.SIGNING_WEB_KEYSTORE }}
+          alias: ${{ secrets.SIGNING_WEB_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_WEB_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_WEB_KEY_PASSWORD }}
+      - name: Releasing using Hub
+        uses: kyze8439690/action-release-releaseapk@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          APP_FOLDER: app


### PR DESCRIPTION
In order to comply with F-Droid's policies, we need to have a build available along with the source code when we do a release. This script is to generate the respective apk upon creating a tag.