### PR TITLE
PIA-XXXX: Update accounts library to `1.5.0`

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -141,7 +141,7 @@ object Dependencies {
     }
 
     fun DependencyHandler.implementAccount() {
-        add(IMPLEMENTATION, "com.kape.android:account-android:1.4.7")
+        add(IMPLEMENTATION, "com.kape.android:account-android:1.5.0")
     }
 
     fun DependencyHandler.implementKpi() {

--- a/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
+++ b/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
@@ -6,34 +6,34 @@ import com.kape.payments.data.Subscription
 import com.kape.utils.Prefs
 import kotlinx.serialization.json.Json
 
-private const val AVAILABLE_SUBSCRIPTIONS = "available-subscriptions"
-private const val PURCHASE_DATA = "purchase-data"
+private const val AVAILABLE_VPN_SUBSCRIPTIONS = "available-subscriptions"
+private const val VPN_PURCHASE_DATA = "purchase-data"
 class SubscriptionPrefs(context: Context) : Prefs(context, "subscriptions") {
 
-    fun storeSubscriptions(available: List<Subscription>) {
+    fun storeVpnSubscriptions(available: List<Subscription>) {
         val validData = mutableSetOf<String>()
         for (item in available) {
             if (!item.legacy) {
                 validData.add(item.toString())
             }
         }
-        prefs.edit().putStringSet(AVAILABLE_SUBSCRIPTIONS, validData).apply()
+        prefs.edit().putStringSet(AVAILABLE_VPN_SUBSCRIPTIONS, validData).apply()
     }
 
-    fun getSubscriptions(): List<Subscription> {
+    fun getVpnSubscriptions(): List<Subscription> {
         val data = mutableListOf<Subscription>()
-        for (item in prefs.getStringSet(AVAILABLE_SUBSCRIPTIONS, emptySet())!!) {
+        for (item in prefs.getStringSet(AVAILABLE_VPN_SUBSCRIPTIONS, emptySet())!!) {
             data.add(Json.decodeFromString(item))
         }
         return data
     }
 
-    fun storePurchaseData(purchaseData: PurchaseData) {
-        prefs.edit().putString(PURCHASE_DATA, purchaseData.toString()).apply()
+    fun storeVpnPurchaseData(purchaseData: PurchaseData) {
+        prefs.edit().putString(VPN_PURCHASE_DATA, purchaseData.toString()).apply()
     }
 
-    fun getPurchaseData(): PurchaseData? {
-        val data = prefs.getString(PURCHASE_DATA, null)
+    fun getVpnPurchaseData(): PurchaseData? {
+        val data = prefs.getString(VPN_PURCHASE_DATA, null)
         return if (data == null) {
             data
         } else {

--- a/core/payments/src/amazon/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
@@ -13,7 +13,7 @@ class SubscriptionDataSourceImpl(
     private val api: AndroidAccountAPI,
 ) : SubscriptionDataSource, KoinComponent {
 
-    override fun getAvailableSubscriptions(): Flow<List<Subscription>> = callbackFlow {
+    override fun getAvailableVpnSubscriptions(): Flow<List<Subscription>> = callbackFlow {
         api.amazonSubscriptions { details, error ->
             if (error.isNotEmpty() || details == null) {
                 trySend(emptyList())
@@ -23,8 +23,8 @@ class SubscriptionDataSourceImpl(
             for (item in details.availableProducts) {
                 data.add(Subscription(item.id, item.legacy, item.plan, item.price))
             }
-            prefs.storeSubscriptions(data)
-            trySend(prefs.getSubscriptions())
+            prefs.storeVpnSubscriptions(data)
+            trySend(prefs.getVpnSubscriptions())
         }
         awaitClose { channel.close() }
     }

--- a/core/payments/src/amazon/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.flow
 
 class GetSubscriptionsUseCase(private val source: SubscriptionDataSource) {
 
-    suspend fun getSubscriptions(): Flow<List<Subscription>> = flow {
-        source.getAvailableSubscriptions().collect {
+    suspend fun getVpnSubscriptions(): Flow<List<Subscription>> = flow {
+        source.getAvailableVpnSubscriptions().collect {
             emit(it)
         }
     }

--- a/core/payments/src/amazon/java/com/kape/payments/ui/PaymentProviderImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/ui/PaymentProviderImpl.kt
@@ -64,7 +64,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
                             yearly.formattedPrice = perYear.price
                             val monthly = getMonthlySubscription()
                             monthly.formattedPrice = perMonth.price
-                            prefs.storeSubscriptions(listOf(yearly, monthly))
+                            prefs.storeVpnSubscriptions(listOf(yearly, monthly))
                             purchaseState.value = PurchaseState.ProductsLoadedSuccess
                         } else {
                             purchaseState.value = PurchaseState.ProductsLoadedFailed
@@ -80,7 +80,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
 
                 override fun onPurchaseUpdatesResponse(purchaseUpdate: PurchaseUpdatesResponse?) {
                     purchaseUpdate?.let {
-                        prefs.storePurchaseData(
+                        prefs.storeVpnPurchaseData(
                             PurchaseData(
                                 it.userData.userId,
                                 it.receipts.first().receiptId,
@@ -94,10 +94,10 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
     }
 
     override fun getMonthlySubscription(): Subscription =
-        prefs.getSubscriptions().first { plan -> plan.id == M1 }
+        prefs.getVpnSubscriptions().first { plan -> plan.id == M1 }
 
     override fun getYearlySubscription(): Subscription =
-        prefs.getSubscriptions().first { plan -> plan.id == Y1 }
+        prefs.getVpnSubscriptions().first { plan -> plan.id == Y1 }
 
     override fun loadProducts() {
         PurchasingService.getProductData(products)
@@ -131,7 +131,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
         if (purchase != null) {
             when (purchase.requestStatus) {
                 PurchaseResponse.RequestStatus.SUCCESSFUL -> {
-                    prefs.storePurchaseData(
+                    prefs.storeVpnPurchaseData(
                         PurchaseData(
                             purchase.userData.userId,
                             purchase.receipt.receiptId,

--- a/core/payments/src/google/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
+++ b/core/payments/src/google/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
@@ -13,18 +13,18 @@ class SubscriptionDataSourceImpl(
     private val api: AndroidAccountAPI,
 ) : SubscriptionDataSource, KoinComponent {
 
-    override fun getAvailableSubscriptions(): Flow<List<Subscription>> = callbackFlow {
-        api.subscriptions { details, error ->
+    override fun getAvailableVpnSubscriptions(): Flow<List<Subscription>> = callbackFlow {
+        api.vpnSubscriptions { details, error ->
             if (error.isNotEmpty() || details == null) {
                 trySend(emptyList())
-                return@subscriptions
+                return@vpnSubscriptions
             }
             val data = mutableListOf<Subscription>()
             for (item in details.availableProducts) {
                 data.add(Subscription(item.id, item.legacy, item.plan, item.price, null))
             }
-            prefs.storeSubscriptions(data)
-            trySend(prefs.getSubscriptions())
+            prefs.storeVpnSubscriptions(data)
+            trySend(prefs.getVpnSubscriptions())
         }
         awaitClose { channel.close() }
     }

--- a/core/payments/src/google/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
+++ b/core/payments/src/google/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.flow.flow
 
 class GetSubscriptionsUseCase(private val source: SubscriptionDataSource) {
 
-    fun getSubscriptions(): Flow<List<Subscription>> = flow {
-        source.getAvailableSubscriptions().collect {
+    fun getVpnSubscriptions(): Flow<List<Subscription>> = flow {
+        source.getAvailableVpnSubscriptions().collect {
             emit(it)
         }
     }

--- a/core/payments/src/google/java/com/kape/payments/ui/PaymentProviderImpl.kt
+++ b/core/payments/src/google/java/com/kape/payments/ui/PaymentProviderImpl.kt
@@ -41,7 +41,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
                     BillingClient.BillingResponseCode.OK -> {
                         val purchase = purchases.first()
                         purchase.orderId?.let {
-                            prefs.storePurchaseData(
+                            prefs.storeVpnPurchaseData(
                                 PurchaseData(
                                     purchase.purchaseToken,
                                     purchase.products.first(),
@@ -85,16 +85,16 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
         )
     }
 
-    override fun getMonthlySubscription(): Subscription = prefs.getSubscriptions().first {
+    override fun getMonthlySubscription(): Subscription = prefs.getVpnSubscriptions().first {
         it.plan.lowercase() == monthlySubscription.lowercase()
     }
 
-    override fun getYearlySubscription(): Subscription = prefs.getSubscriptions().first {
+    override fun getYearlySubscription(): Subscription = prefs.getVpnSubscriptions().first {
         it.plan.lowercase() == yearlySubscription.lowercase()
     }
 
     override fun loadProducts() {
-        if (prefs.getSubscriptions().isEmpty()) {
+        if (prefs.getVpnSubscriptions().isEmpty()) {
             purchaseState.value = PurchaseState.ProductsLoadedFailed
         } else {
             loadProviderProducts()
@@ -112,7 +112,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
                 productDetailsList,
             ->
             if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                val data = prefs.getSubscriptions()
+                val data = prefs.getVpnSubscriptions()
                 for (item in productDetailsList) {
                     if (data.any { it.id == item.productId }) {
                         item.subscriptionOfferDetails?.let {
@@ -131,7 +131,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
                         }
                     }
                 }
-                prefs.storeSubscriptions(data)
+                prefs.storeVpnSubscriptions(data)
                 availableProducts.clear()
                 availableProducts.addAll(productDetailsList)
                 purchaseState.value = PurchaseState.ProductsLoadedSuccess
@@ -220,7 +220,7 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
 
     private fun createProductsListForQuery(): List<QueryProductDetailsParams.Product> {
         val result = mutableListOf<QueryProductDetailsParams.Product>()
-        for (product in prefs.getSubscriptions()) {
+        for (product in prefs.getVpnSubscriptions()) {
             result.add(
                 QueryProductDetailsParams.Product.newBuilder()
                     .setProductId(product.id)

--- a/core/payments/src/main/java/com/kape/payments/domain/GetPurchaseDetailsUseCase.kt
+++ b/core/payments/src/main/java/com/kape/payments/domain/GetPurchaseDetailsUseCase.kt
@@ -5,5 +5,5 @@ import com.kape.payments.data.PurchaseData
 
 class GetPurchaseDetailsUseCase(private val prefs: SubscriptionPrefs) {
 
-    fun getPurchaseDetails(): PurchaseData? = prefs.getPurchaseData()
+    fun getPurchaseDetails(): PurchaseData? = prefs.getVpnPurchaseData()
 }

--- a/core/payments/src/main/java/com/kape/payments/domain/SubscriptionDataSource.kt
+++ b/core/payments/src/main/java/com/kape/payments/domain/SubscriptionDataSource.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SubscriptionDataSource {
 
-    fun getAvailableSubscriptions(): Flow<List<Subscription>>
+    fun getAvailableVpnSubscriptions(): Flow<List<Subscription>>
 }

--- a/core/payments/src/noinapp/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/data/SubscriptionDataSourceImpl.kt
@@ -12,7 +12,7 @@ class SubscriptionDataSourceImpl(
     private val api: AndroidAccountAPI,
 ) : SubscriptionDataSource, KoinComponent {
 
-    override fun getAvailableSubscriptions(): Flow<List<Subscription>> = flow {
+    override fun getAvailableVpnSubscriptions(): Flow<List<Subscription>> = flow {
         emit(emptyList())
     }
 }

--- a/core/payments/src/noinapp/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/domain/GetSubscriptionsUseCase.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.flow
 
 class GetSubscriptionsUseCase(private val source: SubscriptionDataSource) {
 
-    fun getSubscriptions(): Flow<List<Subscription>> = flow {
+    fun getVpnSubscriptions(): Flow<List<Subscription>> = flow {
         emit(emptyList())
     }
 }

--- a/core/payments/src/noinapp/java/com/kape/payments/ui/PaymentProviderImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/ui/PaymentProviderImpl.kt
@@ -23,11 +23,11 @@ class PaymentProviderImpl(private val prefs: SubscriptionPrefs, var activity: Ac
         this.activity = activity
     }
 
-    override fun getMonthlySubscription(): Subscription = prefs.getSubscriptions().first {
+    override fun getMonthlySubscription(): Subscription = prefs.getVpnSubscriptions().first {
         it.plan.lowercase() == monthlySubscription.lowercase()
     }
 
-    override fun getYearlySubscription(): Subscription = prefs.getSubscriptions().first {
+    override fun getYearlySubscription(): Subscription = prefs.getVpnSubscriptions().first {
         it.plan.lowercase() == yearlySubscription.lowercase()
     }
 

--- a/core/payments/src/testAmazon/java/com/kape/payments/data/SubscriptionDataSourceImplTest.kt
+++ b/core/payments/src/testAmazon/java/com/kape/payments/data/SubscriptionDataSourceImplTest.kt
@@ -64,7 +64,7 @@ internal class SubscriptionDataSourceImplTest {
             lastArg<(AmazonSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(null, errorList)
         }
 
-        source.getAvailableSubscriptions().test {
+        source.getAvailableVpnSubscriptions().test {
             val actual = awaitItem()
             assertEquals(emptyList(), actual)
         }
@@ -78,10 +78,10 @@ internal class SubscriptionDataSourceImplTest {
         coEvery { api.amazonSubscriptions(any()) } answers {
             lastArg<(AmazonSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(data, emptyList())
         }
-        every { prefs.storeSubscriptions(any()) } returns Unit
-        every { prefs.getSubscriptions() } returns expected
+        every { prefs.storeVpnSubscriptions(any()) } returns Unit
+        every { prefs.getVpnSubscriptions() } returns expected
 
-        source.getAvailableSubscriptions().test {
+        source.getAvailableVpnSubscriptions().test {
             val actual = awaitItem()
             assertEquals(expected, actual)
         }

--- a/core/payments/src/testAmazon/java/com/kape/payments/domain/GetSubscriptionsUseCaseTest.kt
+++ b/core/payments/src/testAmazon/java/com/kape/payments/domain/GetSubscriptionsUseCaseTest.kt
@@ -27,10 +27,10 @@ internal class GetSubscriptionsUseCaseTest {
             Subscription("id", false, "monthly", 3.99),
             Subscription("id", false, "yearly", 49.99),
         )
-        every { source.getAvailableSubscriptions() } returns flow {
+        every { source.getAvailableVpnSubscriptions() } returns flow {
             emit(expected)
         }
-        useCase.getSubscriptions().test {
+        useCase.getVpnSubscriptions().test {
             val actual = awaitItem()
             awaitComplete()
             assertEquals(expected, actual)
@@ -40,10 +40,10 @@ internal class GetSubscriptionsUseCaseTest {
     @Test
     fun `getSubscriptions() - failed`() = runTest {
         val expected = emptyList<Subscription>()
-        every { source.getAvailableSubscriptions() } returns flow {
+        every { source.getAvailableVpnSubscriptions() } returns flow {
             emit(expected)
         }
-        useCase.getSubscriptions().test {
+        useCase.getVpnSubscriptions().test {
             val actual = awaitItem()
             awaitComplete()
             assertEquals(expected, actual)

--- a/core/payments/src/testGoogle/java/com/kape/payments/data/SubscriptionDataSourceImplTest.kt
+++ b/core/payments/src/testGoogle/java/com/kape/payments/data/SubscriptionDataSourceImplTest.kt
@@ -6,7 +6,7 @@ import com.kape.payments.di.paymentsModule
 import com.kape.payments.domain.SubscriptionDataSource
 import com.privateinternetaccess.account.AccountRequestError
 import com.privateinternetaccess.account.AndroidAccountAPI
-import com.privateinternetaccess.account.model.response.AndroidSubscriptionsInformation
+import com.privateinternetaccess.account.model.response.AndroidVpnSubscriptionsInformation
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -59,11 +59,11 @@ internal class SubscriptionDataSourceImplTest {
     @ParameterizedTest(name = "api: {0}")
     @MethodSource("accountApiResults")
     fun `getAvailableSubscriptions() - unsuccessful`(errorList: List<AccountRequestError>) = runTest {
-        coEvery { api.subscriptions(any()) } answers {
-            lastArg<(AndroidSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(null, errorList)
+        coEvery { api.vpnSubscriptions(any()) } answers {
+            lastArg<(AndroidVpnSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(null, errorList)
         }
 
-        source.getAvailableSubscriptions().test {
+        source.getAvailableVpnSubscriptions().test {
             val actual = awaitItem()
             kotlin.test.assertEquals(emptyList(), actual)
         }
@@ -72,15 +72,15 @@ internal class SubscriptionDataSourceImplTest {
     @Test
     fun `getAvailableSubscriptions - successful`() = runTest {
         val data =
-            AndroidSubscriptionsInformation(listOf(AndroidSubscriptionsInformation.AvailableProduct("id", false, "monthly", "3.99")), "ok")
+            AndroidVpnSubscriptionsInformation(listOf(AndroidVpnSubscriptionsInformation.AvailableProduct("id", false, "monthly", "3.99")), "ok")
         val expected = listOf(Subscription("id", false, "monthly", "3.99", "$ 3.99"))
-        coEvery { api.subscriptions(any()) } answers {
-            lastArg<(AndroidSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(data, emptyList())
+        coEvery { api.vpnSubscriptions(any()) } answers {
+            lastArg<(AndroidVpnSubscriptionsInformation?, List<AccountRequestError>) -> Unit>().invoke(data, emptyList())
         }
-        every { prefs.storeSubscriptions(any()) } returns Unit
-        every { prefs.getSubscriptions() } returns expected
+        every { prefs.storeVpnSubscriptions(any()) } returns Unit
+        every { prefs.getVpnSubscriptions() } returns expected
 
-        source.getAvailableSubscriptions().test {
+        source.getAvailableVpnSubscriptions().test {
             val actual = awaitItem()
             kotlin.test.assertEquals(expected, actual)
         }

--- a/core/payments/src/testGoogle/java/com/kape/payments/domain/GetPurchaseDetailsUseCaseTest.kt
+++ b/core/payments/src/testGoogle/java/com/kape/payments/domain/GetPurchaseDetailsUseCaseTest.kt
@@ -24,7 +24,7 @@ class GetPurchaseDetailsUseCaseTest {
     @ParameterizedTest(name = "expected: {0}")
     @MethodSource("prefsValues")
     fun `test getPurchaseDetails`(expected: PurchaseData?) = runTest {
-        every { prefs.getPurchaseData() } returns expected
+        every { prefs.getVpnPurchaseData() } returns expected
 
         val result = useCase.getPurchaseDetails()
         assertEquals(expected, result)

--- a/core/payments/src/testGoogle/java/com/kape/payments/domain/GetSubscriptionsUseCaseTest.kt
+++ b/core/payments/src/testGoogle/java/com/kape/payments/domain/GetSubscriptionsUseCaseTest.kt
@@ -25,10 +25,10 @@ internal class GetSubscriptionsUseCaseTest {
             Subscription("id", false, "monthly", "3.99", "$ 3.99"),
             Subscription("id", false, "yearly", "49.99", "$ 49.99"),
         )
-        every { source.getAvailableSubscriptions() } returns flow {
+        every { source.getAvailableVpnSubscriptions() } returns flow {
             emit(expected)
         }
-        useCase.getSubscriptions().test {
+        useCase.getVpnSubscriptions().test {
             val actual = awaitItem()
             awaitComplete()
             kotlin.test.assertEquals(expected, actual)
@@ -38,10 +38,10 @@ internal class GetSubscriptionsUseCaseTest {
     @Test
     fun `getSubscriptions() - failed`() = runTest {
         val expected = emptyList<Subscription>()
-        every { source.getAvailableSubscriptions() } returns flow {
+        every { source.getAvailableVpnSubscriptions() } returns flow {
             emit(expected)
         }
-        useCase.getSubscriptions().test {
+        useCase.getVpnSubscriptions().test {
             val actual = awaitItem()
             awaitComplete()
             kotlin.test.assertEquals(expected, actual)

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipDataSourceImpl.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipDataSourceImpl.kt
@@ -20,10 +20,10 @@ class DipDataSourceImpl(
 ) : DipDataSource {
 
     override fun activate(ipToken: String): Flow<DipApiResult> = callbackFlow {
-        accountApi.dedicatedIPs(listOf(ipToken)) { details, errors ->
+        accountApi.redeemDedicatedIPs(listOf(ipToken)) { details, errors ->
             if (errors.isNotEmpty()) {
                 trySend(DipApiResult.Error)
-                return@dedicatedIPs
+                return@redeemDedicatedIPs
             }
             val activated = details.firstOrNull { it.dipToken == ipToken }
             activated?.let {

--- a/features/dedicatedip/src/test/java/com/kape/dedicatedip/data/DipDataSourceImplTest.kt
+++ b/features/dedicatedip/src/test/java/com/kape/dedicatedip/data/DipDataSourceImplTest.kt
@@ -56,7 +56,7 @@ class DipDataSourceImplTest {
                 status = DedicatedIPInformationResponse.Status.active,
             )
             every { prefs.addDedicatedIp(any()) } returns Unit
-            coEvery { api.dedicatedIPs(any(), any()) } answers {
+            coEvery { api.redeemDedicatedIPs(any(), any()) } answers {
                 lastArg<(List<DedicatedIPInformationResponse.DedicatedIPInformation>, List<AccountRequestError>) -> Unit>().invoke(
                     listOf(dipInfo),
                     emptyList(),
@@ -74,7 +74,7 @@ class DipDataSourceImplTest {
     @MethodSource("accountApiResults")
     fun activateFail(errorList: List<AccountRequestError>, expected: DipApiResult) =
         runTest {
-            coEvery { api.dedicatedIPs(any(), any()) } answers {
+            coEvery { api.redeemDedicatedIPs(any(), any()) } answers {
                 lastArg<(List<DedicatedIPInformationResponse.DedicatedIPInformation>, List<AccountRequestError>) -> Unit>().invoke(
                     emptyList(),
                     errorList,

--- a/features/signup/src/amazon/java/com/kape/signup/data/SignupDataSourceImpl.kt
+++ b/features/signup/src/amazon/java/com/kape/signup/data/SignupDataSourceImpl.kt
@@ -11,7 +11,7 @@ import org.koin.core.component.KoinComponent
 
 class SignupDataSourceImpl(private val api: AndroidAccountAPI) : SignupDataSource, KoinComponent {
 
-    override fun signup(vararg data: String): Flow<Credentials?> = callbackFlow {
+    override fun vpnSignup(vararg data: String): Flow<Credentials?> = callbackFlow {
         api.amazonSignUp(AmazonSignupInformation(data[0], data[1], data[2])) { details, error ->
             if (error.isNotEmpty() || details == null) {
                 trySend(null)

--- a/features/signup/src/amazon/java/com/kape/signup/domain/SignupUseCase.kt
+++ b/features/signup/src/amazon/java/com/kape/signup/domain/SignupUseCase.kt
@@ -13,13 +13,13 @@ class SignupUseCase(
     private val purchaseDetailsUseCase: GetPurchaseDetailsUseCase,
 ) {
 
-    suspend fun signup(email: String): Flow<Credentials?> = flow {
+    suspend fun vpnSignup(email: String): Flow<Credentials?> = flow {
         val purchaseData = purchaseDetailsUseCase.getPurchaseDetails()
         if (purchaseData == null) {
             emit(null)
             return@flow
         }
-        signupDataSource.signup(purchaseData.userId, purchaseData.receiptId, email).collect {
+        signupDataSource.vpnSignup(purchaseData.userId, purchaseData.receiptId, email).collect {
             emit(it)
         }
     }

--- a/features/signup/src/google/java/com/kape/signup/data/SignupDataSourceImpl.kt
+++ b/features/signup/src/google/java/com/kape/signup/data/SignupDataSourceImpl.kt
@@ -3,7 +3,7 @@ package com.kape.signup.data
 import com.kape.signup.data.models.Credentials
 import com.kape.signup.domain.SignupDataSource
 import com.privateinternetaccess.account.AndroidAccountAPI
-import com.privateinternetaccess.account.model.request.AndroidSignupInformation
+import com.privateinternetaccess.account.model.request.AndroidVpnSignupInformation
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -13,12 +13,12 @@ private const val STORE = "google_play"
 
 class SignupDataSourceImpl(private val api: AndroidAccountAPI) : SignupDataSource, KoinComponent {
 
-    override fun signup(vararg data: String): Flow<Credentials?> = callbackFlow {
-        val receipt = AndroidSignupInformation.Receipt(data[0], data[1], data[2])
-        api.signUp(AndroidSignupInformation(STORE, receipt)) { details, error ->
+    override fun vpnSignup(vararg data: String): Flow<Credentials?> = callbackFlow {
+        val receipt = AndroidVpnSignupInformation.Receipt(data[0], data[1], data[2])
+        api.vpnSignUp(AndroidVpnSignupInformation(STORE, receipt)) { details, error ->
             if (error.isNotEmpty() || details == null) {
                 trySend(null)
-                return@signUp
+                return@vpnSignUp
             }
             trySend(Credentials(details.status, details.username, details.password))
         }

--- a/features/signup/src/google/java/com/kape/signup/domain/SignupUseCase.kt
+++ b/features/signup/src/google/java/com/kape/signup/domain/SignupUseCase.kt
@@ -14,13 +14,13 @@ class SignupUseCase(
     private val purchaseDetailsUseCase: GetPurchaseDetailsUseCase,
 ) {
 
-    suspend fun signup(email: String): Flow<Credentials?> = flow {
+    suspend fun vpnSignup(email: String): Flow<Credentials?> = flow {
         val purchaseData = purchaseDetailsUseCase.getPurchaseDetails()
         if (purchaseData == null) {
             emit(null)
             return@flow
         }
-        signupDataSource.signup(purchaseData.orderId, purchaseData.token, purchaseData.productId)
+        signupDataSource.vpnSignup(purchaseData.orderId, purchaseData.token, purchaseData.productId)
             .collect { credentials ->
                 credentials?.let { data ->
                     loginUseCase.login(data.username, data.password).collect { loginState ->

--- a/features/signup/src/main/java/com/kape/signup/domain/SignupDataSource.kt
+++ b/features/signup/src/main/java/com/kape/signup/domain/SignupDataSource.kt
@@ -10,5 +10,5 @@ interface SignupDataSource {
      * vararg for Google: orderId, token, productId
      */
 
-    fun signup(vararg data: String): Flow<Credentials?>
+    fun vpnSignup(vararg data: String): Flow<Credentials?>
 }

--- a/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
@@ -159,8 +159,8 @@ class SignupViewModel(
     }
 
     fun loadPrices() = viewModelScope.launch {
-        if (subscriptionPrefs.getSubscriptions().isEmpty()) {
-            subscriptionsUseCase.getSubscriptions().collect {
+        if (subscriptionPrefs.getVpnSubscriptions().isEmpty()) {
+            subscriptionsUseCase.getVpnSubscriptions().collect {
                 paymentProvider.loadProducts()
             }
         } else {
@@ -211,7 +211,7 @@ class SignupViewModel(
             return@launch
         }
         _state.emit(IN_PROCESS)
-        useCase.signup(email).collect {
+        useCase.vpnSignup(email).collect {
             if (it == null) {
                 _state.emit(ERROR_REGISTRATION)
             } else {

--- a/features/signup/src/noinapp/java/com/kape/signup/data/SignupDataSourceImpl.kt
+++ b/features/signup/src/noinapp/java/com/kape/signup/data/SignupDataSourceImpl.kt
@@ -11,5 +11,5 @@ private const val STORE = "noinapp"
 
 class SignupDataSourceImpl(private val api: AndroidAccountAPI) : SignupDataSource, KoinComponent {
 
-    override fun signup(vararg data: String): Flow<Credentials?> = flow { emit(null) }
+    override fun vpnSignup(vararg data: String): Flow<Credentials?> = flow { emit(null) }
 }

--- a/features/signup/src/noinapp/java/com/kape/signup/domain/SignupUseCase.kt
+++ b/features/signup/src/noinapp/java/com/kape/signup/domain/SignupUseCase.kt
@@ -13,7 +13,7 @@ class SignupUseCase(
     private val purchaseDetailsUseCase: GetPurchaseDetailsUseCase,
 ) {
 
-    fun signup(email: String): Flow<Credentials?> = flow {
+    fun vpnSignup(email: String): Flow<Credentials?> = flow {
         emit(null)
     }
 }

--- a/features/signup/src/testGoogle/java/com/kape/signup/data/SignupDataSourceImplTest.kt
+++ b/features/signup/src/testGoogle/java/com/kape/signup/data/SignupDataSourceImplTest.kt
@@ -4,7 +4,7 @@ import app.cash.turbine.test
 import com.kape.signup.data.models.Credentials
 import com.kape.signup.di.signupModule
 import com.privateinternetaccess.account.AndroidAccountAPI
-import com.privateinternetaccess.account.model.response.SignUpInformation
+import com.privateinternetaccess.account.model.response.VpnSignUpInformation
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -36,11 +36,11 @@ internal class SignupDataSourceImplTest {
     @Test
     fun `signup success`() = runTest {
         val expected = Credentials("ok", "username", "password")
-        val signupInfo = SignUpInformation(expected.status, expected.username, expected.password)
-        coEvery { api.signUp(any(), any()) } answers {
-            lastArg<(SignUpInformation?, List<Error>) -> Unit>().invoke(signupInfo, emptyList())
+        val signupInfo = VpnSignUpInformation(expected.status, expected.username, expected.password)
+        coEvery { api.vpnSignUp(any(), any()) } answers {
+            lastArg<(VpnSignUpInformation?, List<Error>) -> Unit>().invoke(signupInfo, emptyList())
         }
-        source.signup("orderId", "token", "productId").test {
+        source.vpnSignup("orderId", "token", "productId").test {
             val actual = awaitItem()
             kotlin.test.assertEquals(expected, actual)
         }
@@ -49,10 +49,10 @@ internal class SignupDataSourceImplTest {
     @Test
     fun `signup fails`() = runTest {
         val expected = null
-        coEvery { api.signUp(any(), any()) } answers {
-            lastArg<(SignUpInformation?, List<Error>) -> Unit>().invoke(expected, listOf(Error()))
+        coEvery { api.vpnSignUp(any(), any()) } answers {
+            lastArg<(VpnSignUpInformation?, List<Error>) -> Unit>().invoke(expected, listOf(Error()))
         }
-        source.signup("orderId", "token", "productId").test {
+        source.vpnSignup("orderId", "token", "productId").test {
             val actual = awaitItem()
             kotlin.test.assertEquals(expected, actual)
         }

--- a/features/signup/src/testGoogle/java/com/kape/signup/domain/SignupUseCaseTest.kt
+++ b/features/signup/src/testGoogle/java/com/kape/signup/domain/SignupUseCaseTest.kt
@@ -43,11 +43,11 @@ internal class SignupUseCaseTest : KoinTest {
         every { emailDataSource.setEmail(any()) } returns flow {
             emit(true)
         }
-        coEvery { signupDataSource.signup(any(), any(), any()) } returns flow {
+        coEvery { signupDataSource.vpnSignup(any(), any(), any()) } returns flow {
             emit(expected)
         }
 
-        useCase.signup("email").test {
+        useCase.vpnSignup("email").test {
             val actual = awaitItem()
             awaitComplete()
             assertEquals(expected, actual)

--- a/features/splash/src/main/java/com/kape/splash/ui/vm/SplashViewModel.kt
+++ b/features/splash/src/main/java/com/kape/splash/ui/vm/SplashViewModel.kt
@@ -14,7 +14,7 @@ class SplashViewModel(
 ) : ViewModel(), KoinComponent {
 
     fun load() = viewModelScope.launch {
-        useCase.getSubscriptions().collect {
+        useCase.getVpnSubscriptions().collect {
             router.handleFlow(ExitFlow.Splash)
         }
     }


### PR DESCRIPTION
## Summary

- It updates the `accounts` library to `1.5.0`.
- It updates the subscription methods with the prefix `vpn*` as it is no longer the only subscription.

## Sanity Tests

- [x] Compile the google flavor. Confirm it compiles successfully.
- [x] Compile the amazon flavor. Confirm it compiles successfully.
- [x] Compile the web flavor. Confirm it compiles successfully. 