### PR TITLE
PIA-1919: Introduce DIP signup API acknowledging purchase

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -141,7 +141,7 @@ object Dependencies {
     }
 
     fun DependencyHandler.implementAccount() {
-        add(IMPLEMENTATION, "com.kape.android:account-android:1.5.0")
+        add(IMPLEMENTATION, "com.kape.android:account-android:1.5.1")
     }
 
     fun DependencyHandler.implementKpi() {

--- a/capabilities/ui/src/main/res/values/strings.xml
+++ b/capabilities/ui/src/main/res/values/strings.xml
@@ -152,6 +152,8 @@
     <string name="dip_signup_banner_home_description">Would you like to add a Dedicated IP to your subscription?</string>
     <string name="dip_signup_banner_activate_description">Don\'t have a Dedicated IP token yet?</string>
     <string name="dip_signup_error">It looks like you subscribed on the PIA website and you cannot buy the add-on directly from here. Please return to the website and purchase your Dedicated IP add-on.</string>
+    <string name="dip_signup_required_information_missing_error">An error occurred when retrieving the required information. Please try again later.</string>
+    <string name="dip_signup_purchase_validation_error">An error occurred validating the purchase. You will not be charged until the validation is successful. Please try again.</string>
     <string name="dip_signup_supported_countries_title">You\'ll be able to select only one of the available locations below</string>
     <string name="dip_signup_banner_activate_benefit_one">Avoid CAPTCHAs</string>
     <string name="dip_signup_banner_activate_benefit_two">Avoid blocklists</string>

--- a/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
@@ -3,6 +3,7 @@ package com.kape.dip
 import android.content.Context
 import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.dip.data.DedicatedIpSignupPlans
+import com.kape.dip.data.DedicatedIpSupportedCountries
 import com.kape.utils.Prefs
 import com.privateinternetaccess.account.model.response.DedicatedIPInformationResponse
 import kotlinx.serialization.encodeToString
@@ -12,6 +13,7 @@ private const val DEDICATED_IPS = "dedicated-ips"
 private const val DIP_SIGNUP_ENABLED = "dip-signup-enabled"
 private const val DIP_SIGNUP_HOME_BANNER_VISIBLE = "dip-signup-home-banner-visible"
 private const val DIP_SIGNUP_PLANS = "dip-signup-plans"
+private const val DIP_SUPPORTED_COUNTRIES = "dip-supported-countries"
 private const val DIP_SIGNUP_PURCHASED_TOKEN = "dip-signup-purchased-token"
 
 class DipPrefs(
@@ -69,6 +71,20 @@ class DipPrefs(
 
     fun getDedicatedIpSignupPlans(): DedicatedIpSignupPlans? =
         prefs.getString(DIP_SIGNUP_PLANS, null)?.let {
+            Json.decodeFromString(it)
+        }
+
+    fun setDedicatedIpSupportedCountries(
+        dedicatedIpSupportedCountries: DedicatedIpSupportedCountries,
+    ) {
+        prefs.edit().putString(
+            DIP_SUPPORTED_COUNTRIES,
+            Json.encodeToString(dedicatedIpSupportedCountries),
+        ).apply()
+    }
+
+    fun getDedicatedIpSupportedCountries(): DedicatedIpSupportedCountries? =
+        prefs.getString(DIP_SUPPORTED_COUNTRIES, null)?.let {
             Json.decodeFromString(it)
         }
 

--- a/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSupportedCountries.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSupportedCountries.kt
@@ -1,0 +1,10 @@
+package com.kape.dip.data
+
+import com.privateinternetaccess.account.model.response.DipCountriesResponse
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DedicatedIpSupportedCountries(
+    val persistedTimestamp: Long,
+    val supportedCountries: DipCountriesResponse,
+)

--- a/core/localprefs/payments/build.gradle.kts
+++ b/core/localprefs/payments/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.jlleitschuh.gradle.ktlint")
+    id("kotlinx-serialization")
 }
 
 android {

--- a/core/localprefs/payments/data/src/amazon/java/com/kape/payments/data/DipPurchaseData.kt
+++ b/core/localprefs/payments/data/src/amazon/java/com/kape/payments/data/DipPurchaseData.kt
@@ -1,0 +1,6 @@
+package com.kape.payments.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DipPurchaseData(val token: String, val productId: String, val orderId: String)

--- a/core/localprefs/payments/data/src/google/java/com/kape/payments/data/DipPurchaseData.kt
+++ b/core/localprefs/payments/data/src/google/java/com/kape/payments/data/DipPurchaseData.kt
@@ -1,0 +1,6 @@
+package com.kape.payments.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DipPurchaseData(val token: String, val productId: String, val orderId: String)

--- a/core/localprefs/payments/data/src/noinapp/java/com/kape/payments/data/DipPurchaseData.kt
+++ b/core/localprefs/payments/data/src/noinapp/java/com/kape/payments/data/DipPurchaseData.kt
@@ -1,0 +1,6 @@
+package com.kape.payments.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DipPurchaseData(val token: String, val productId: String, val orderId: String)

--- a/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
+++ b/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
@@ -1,6 +1,7 @@
 package com.kape.payments
 
 import android.content.Context
+import com.kape.payments.data.DipPurchaseData
 import com.kape.payments.data.PurchaseData
 import com.kape.payments.data.Subscription
 import com.kape.utils.Prefs
@@ -8,6 +9,8 @@ import kotlinx.serialization.json.Json
 
 private const val AVAILABLE_VPN_SUBSCRIPTIONS = "available-subscriptions"
 private const val VPN_PURCHASE_DATA = "purchase-data"
+private const val DIP_PURCHASE_DATA = "dip-purchase-data"
+
 class SubscriptionPrefs(context: Context) : Prefs(context, "subscriptions") {
 
     fun storeVpnSubscriptions(available: List<Subscription>) {
@@ -39,5 +42,18 @@ class SubscriptionPrefs(context: Context) : Prefs(context, "subscriptions") {
         } else {
             Json.decodeFromString(data)
         }
+    }
+
+    fun storeDipPurchaseData(purchaseData: DipPurchaseData) {
+        prefs.edit().putString(DIP_PURCHASE_DATA, purchaseData.toString()).apply()
+    }
+
+    fun getDipPurchaseData(): DipPurchaseData? =
+        prefs.getString(DIP_PURCHASE_DATA, null)?.let {
+            Json.decodeFromString(it)
+        }
+
+    fun removeDipPurchaseData() {
+        prefs.edit().remove(DIP_PURCHASE_DATA).apply()
     }
 }

--- a/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -1,7 +1,8 @@
 package com.kape.payments.ui
 
+import android.app.Activity
 import android.content.Context
-import com.kape.payments.data.PurchaseData
+import com.kape.payments.data.DipPurchaseData
 
 class DipSubscriptionPaymentProviderImpl(
     private val context: Context,
@@ -16,8 +17,9 @@ class DipSubscriptionPaymentProviderImpl(
     }
 
     override fun purchaseProduct(
+        activity: Activity,
         productId: String,
-        callback: (result: Result<PurchaseData>) -> Unit,
+        callback: (result: Result<DipPurchaseData>) -> Unit,
     ) {
         callback(Result.failure(IllegalStateException("Unsupported")))
     }

--- a/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
+++ b/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
@@ -1,6 +1,7 @@
 package com.kape.payments.ui
 
-import com.kape.payments.data.PurchaseData
+import android.app.Activity
+import com.kape.payments.data.DipPurchaseData
 
 interface DipSubscriptionPaymentProvider {
 
@@ -22,11 +23,13 @@ interface DipSubscriptionPaymentProvider {
     /**
      * It triggers the purchase flow for given product id.
      *
+     * @param activity
      * @param productId
      * @param callback
      */
     fun purchaseProduct(
+        activity: Activity,
         productId: String,
-        callback: (result: Result<PurchaseData>) -> Unit,
+        callback: (result: Result<DipPurchaseData>) -> Unit,
     )
 }

--- a/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -1,7 +1,8 @@
 package com.kape.payments.ui
 
+import android.app.Activity
 import android.content.Context
-import com.kape.payments.data.PurchaseData
+import com.kape.payments.data.DipPurchaseData
 
 class DipSubscriptionPaymentProviderImpl(
     private val context: Context,
@@ -16,8 +17,9 @@ class DipSubscriptionPaymentProviderImpl(
     }
 
     override fun purchaseProduct(
+        activity: Activity,
         productId: String,
-        callback: (result: Result<PurchaseData>) -> Unit,
+        callback: (result: Result<DipPurchaseData>) -> Unit,
     ) {
         callback(Result.failure(IllegalStateException("Unsupported")))
     }

--- a/features/dedicatedip/build.gradle.kts
+++ b/features/dedicatedip/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(project(":core:payments"))
     implementation(project(":core:vpnconnect"))
     implementation(project(":core:localprefs:dip"))
+    implementation(project(":core:localprefs:payments:data"))
+    implementation(project(":core:localprefs:payments"))
     implementation(project(":features:appbar"))
     implementation(project(":capabilities:ui"))
     implementation(project(":capabilities:buildconfig"))

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipSignupRepository.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipSignupRepository.kt
@@ -3,7 +3,9 @@ package com.kape.dedicatedip.data
 import com.kape.dedicatedip.domain.DipDataSource
 import com.kape.dip.DipPrefs
 import com.kape.dip.data.DedicatedIpSignupPlans
+import com.kape.dip.data.DedicatedIpSupportedCountries
 import com.privateinternetaccess.account.model.response.AndroidAddonsSubscriptionsInformation
+import com.privateinternetaccess.account.model.response.DipCountriesResponse
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -15,6 +17,7 @@ class DipSignupRepository(
 
     private companion object {
         private const val DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_1_DAY = 1L * 24 * 60 * 60 * 1000
+        private const val DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_12_HOURS = 1L * 12 * 60 * 60 * 1000
     }
 
     fun signupPlans(): Flow<AndroidAddonsSubscriptionsInformation?> = callbackFlow {
@@ -34,6 +37,23 @@ class DipSignupRepository(
         awaitClose { channel.close() }
     }
 
+    fun dipSupportedCountries(): Flow<DipCountriesResponse?> = callbackFlow {
+        dipPrefs.getDedicatedIpSupportedCountries()?.let {
+            if (System.currentTimeMillis() - it.persistedTimestamp > DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_12_HOURS) {
+                fetchSupportedCountries().collect { fetchedSupportedCountries ->
+                    trySend(fetchedSupportedCountries)
+                }
+            } else {
+                trySend(it.supportedCountries)
+            }
+        } ?: run {
+            fetchSupportedCountries().collect {
+                trySend(it)
+            }
+        }
+        awaitClose { channel.close() }
+    }
+
     // region private
     private fun fetchSignupPlans(): Flow<AndroidAddonsSubscriptionsInformation?> = callbackFlow {
         dipDataSource.signupPlans().collect {
@@ -42,6 +62,21 @@ class DipSignupRepository(
                     dedicatedIpSignupPlans = DedicatedIpSignupPlans(
                         persistedTimestamp = System.currentTimeMillis(),
                         signupPlans = it,
+                    ),
+                )
+            }
+            trySend(it)
+        }
+        awaitClose { channel.close() }
+    }
+
+    private fun fetchSupportedCountries(): Flow<DipCountriesResponse?> = callbackFlow {
+        dipDataSource.supportedCountries().collect {
+            it?.let {
+                dipPrefs.setDedicatedIpSupportedCountries(
+                    dedicatedIpSupportedCountries = DedicatedIpSupportedCountries(
+                        persistedTimestamp = System.currentTimeMillis(),
+                        supportedCountries = it,
                     ),
                 )
             }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
@@ -23,7 +23,7 @@ fun dedicatedIpModule(appModule: Module) = module {
 
 val localDipModule = module {
     single { DipPrefs(get(), get()) }
-    single<DipDataSource> { DipDataSourceImpl(get(), get()) }
+    single<DipDataSource> { DipDataSourceImpl(get(), get(), get()) }
     single { PriceFormatter(get()) }
     single { DipSignupRepository(get(), get()) }
     single { ActivateDipUseCase(get()) }
@@ -33,5 +33,7 @@ val localDipModule = module {
     single { GetDipYearlyPlan(get(), get(), get()) }
     single { ValidateDipSignup(get(), get()) }
     single { GetSignupDipToken(get()) }
-    viewModel { DipViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel {
+        DipViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+    }
 }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/DipDataSource.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/DipDataSource.kt
@@ -1,6 +1,7 @@
 package com.kape.dedicatedip.domain
 
 import com.kape.dedicatedip.utils.DipApiResult
+import com.kape.payments.data.DipPurchaseData
 import com.privateinternetaccess.account.model.response.AndroidAddonsSubscriptionsInformation
 import com.privateinternetaccess.account.model.response.DipCountriesResponse
 import kotlinx.coroutines.flow.Flow
@@ -15,7 +16,5 @@ interface DipDataSource {
 
     fun signupPlans(): Flow<AndroidAddonsSubscriptionsInformation?>
 
-    // Parameters to be replaced by data class with the information needed by the coming API.
-    // We are mocking for now.
-    fun signup(receipt: String = ""): Flow<Result<String>>
+    fun signup(dipPurchaseData: DipPurchaseData): Flow<Result<Unit>>
 }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/GetDipSupportedCountries.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/GetDipSupportedCountries.kt
@@ -1,13 +1,16 @@
 package com.kape.dedicatedip.domain
 
+import com.kape.dedicatedip.data.DipSignupRepository
 import com.privateinternetaccess.account.model.response.DipCountriesResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class GetDipSupportedCountries(private val dataSource: DipDataSource) {
+class GetDipSupportedCountries(
+    private val dipSignupRepository: DipSignupRepository,
+) {
 
     operator fun invoke(): Flow<DipCountriesResponse?> = flow {
-        dataSource.supportedCountries().collect {
+        dipSignupRepository.dipSupportedCountries().collect {
             emit(it)
         }
     }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/ValidateDipSignup.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/ValidateDipSignup.kt
@@ -1,23 +1,27 @@
 package com.kape.dedicatedip.domain
 
-import com.kape.dip.DipPrefs
+import com.kape.payments.SubscriptionPrefs
+import com.kape.payments.data.DipPurchaseData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class ValidateDipSignup(
-    private val dipPrefs: DipPrefs,
+    private val subscriptionPrefs: SubscriptionPrefs,
     private val dataSource: DipDataSource,
 ) {
 
-    fun signup(): Flow<Result<String>> = flow {
-        dataSource.signup().collect { result ->
+    operator fun invoke(dipPurchaseData: DipPurchaseData): Flow<Result<Unit>> = flow {
+        subscriptionPrefs.storeDipPurchaseData(dipPurchaseData)
+        dataSource.signup(dipPurchaseData = dipPurchaseData).collect { result ->
             result.fold(
                 onSuccess = {
-                    dipPrefs.setPurchasedSignupDipToken(it)
+                    subscriptionPrefs.removeDipPurchaseData()
+                    emit(result)
                 },
-                onFailure = { },
+                onFailure = {
+                    emit(result)
+                },
             )
-            emit(result)
         }
     }
 }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -179,7 +179,7 @@ fun BottomScreen(showAllLocations: Boolean, viewModel: DipViewModel) {
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            viewModel.signup()
+            viewModel.navigateToDedicatedIpTokenDetails()
         }
         Spacer(modifier = Modifier.height(8.dp))
         SecondaryButton(

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -61,7 +61,7 @@ fun SignupDedicatedIpCountryScreen() = Screen {
         appBarText(stringResource(id = R.string.dedicated_ip_title))
     }
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getSupportedDipCountries()
+        getDipSupportedCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()
     }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,8 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,11 +52,10 @@ import org.koin.androidx.compose.koinViewModel
 fun SignupDedicatedIpScreen() = Screen {
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
         hasActivePlaystoreSubscription()
-        getSupportedDipCountries()
+        getDipSupportedCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()
     }
-    val showSupportedCountriesDialog = remember { mutableStateOf(true) }
     val context = LocalContext.current
 
     Column(
@@ -76,84 +74,122 @@ fun SignupDedicatedIpScreen() = Screen {
                 .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Column {
-            DedicatedIpSignupTitleText(
-                content = stringResource(id = R.string.dip_signup_addon_title),
+        if (viewModel.showFetchingPlansSpinner.value || viewModel.showValidatingPurchaseSpinner.value) {
+            Column(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
+                    .fillMaxSize()
+                    .padding(bottom = 64.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.padding(8.dp))
+            }
+        } else {
+            Column {
+                DedicatedIpSignupTitleText(
+                    content = stringResource(id = R.string.dip_signup_addon_title),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                DedicatedIpSignupDescriptionText(
+                    content = stringResource(id = R.string.dip_signup_addon_description),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+            YearlySubscriptionCard(
+                selected = viewModel.selectedPlanProductId.value == viewModel.dipYearlyPlan.value?.id,
+                price = viewModel.dipYearlyPlan.value?.yearlyPrice.toString(),
+                perMonthPrice = viewModel.dipYearlyPlan.value?.monthlyPrice.toString(),
+                modifier = Modifier
+                    .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+            ) {
+                viewModel.dipYearlyPlan.value?.let {
+                    viewModel.selectedPlanProductId.value = it.id
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            MonthlySubscriptionCard(
+                selected = viewModel.selectedPlanProductId.value == viewModel.dipMonthlyPlan.value?.id,
+                price = viewModel.dipMonthlyPlan.value?.monthlyPrice.toString(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.dipMonthlyPlan.value?.let {
+                    viewModel.selectedPlanProductId.value = it.id
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            PrimaryButton(
+                text = stringResource(id = R.string.logjn_continue),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.purchaseSubscription(activity = context as Activity)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            SecondaryButton(
+                text = stringResource(id = R.string.cancel),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.navigateBack()
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Footer(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally),
             )
             Spacer(modifier = Modifier.height(16.dp))
-            DedicatedIpSignupDescriptionText(
-                content = stringResource(id = R.string.dip_signup_addon_description),
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(horizontal = 16.dp),
-            )
         }
-        Spacer(modifier = Modifier.height(32.dp))
-        YearlySubscriptionCard(
-            selected = viewModel.selectedPlanProductId.value == viewModel.dipYearlyPlan.value?.id,
-            price = viewModel.dipYearlyPlan.value?.yearlyPrice.toString(),
-            perMonthPrice = viewModel.dipYearlyPlan.value?.monthlyPrice.toString(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.dipYearlyPlan.value?.let {
-                viewModel.selectedPlanProductId.value = it.id
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        MonthlySubscriptionCard(
-            selected = viewModel.selectedPlanProductId.value == viewModel.dipMonthlyPlan.value?.id,
-            price = viewModel.dipMonthlyPlan.value?.monthlyPrice.toString(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.dipMonthlyPlan.value?.let {
-                viewModel.selectedPlanProductId.value = it.id
-            }
-        }
-        Spacer(modifier = Modifier.height(24.dp))
-        PrimaryButton(
-            text = stringResource(id = R.string.logjn_continue),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.purchaseSubscription(activity = context as Activity)
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        SecondaryButton(
-            text = stringResource(id = R.string.cancel),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.navigateBack()
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        Spacer(modifier = Modifier.weight(1f))
-        Footer(
-            modifier = Modifier
-                .padding(16.dp)
-                .align(Alignment.CenterHorizontally),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
     }
 
     if (viewModel.hasAnActivePlaystoreSubscription.value) {
-        if (showSupportedCountriesDialog.value) {
+        if (viewModel.showSupportedCountriesDialog.value) {
             DipSignupSupportedCountriesDialog(viewModel = viewModel) {
-                showSupportedCountriesDialog.value = false
+                viewModel.showSupportedCountriesDialog.value = false
+            }
+        } else {
+            if (viewModel.showFetchingNeededInformationError.value) {
+                DipSignupErrorDialog(
+                    message = stringResource(id = R.string.dip_signup_required_information_missing_error),
+                    confirmButtonMessage = stringResource(id = R.string.take_me_back),
+                    onConfirmCallback = {
+                        viewModel.navigateBack()
+                    },
+                )
             }
         }
     } else {
-        DipSignupErrorDialog() {
-            viewModel.navigateBack()
-        }
+        DipSignupErrorDialog(
+            message = stringResource(id = R.string.dip_signup_error),
+            confirmButtonMessage = stringResource(id = R.string.take_me_back),
+            onConfirmCallback = {
+                viewModel.navigateBack()
+            },
+        )
+    }
+
+    if (viewModel.showPurchaseValidationError.value) {
+        DipSignupErrorDialog(
+            message = stringResource(id = R.string.dip_signup_purchase_validation_error),
+            confirmButtonMessage = stringResource(id = R.string.try_again),
+            onConfirmCallback = {
+                viewModel.validateSubscriptionPurchase()
+            },
+            onDismissCallback = {
+                viewModel.navigateBack()
+            },
+        )
     }
 }
 
@@ -205,9 +241,14 @@ private fun DipSignupSupportedCountriesDialog(
 }
 
 @Composable
-private fun DipSignupErrorDialog(onDismiss: () -> Unit) {
+fun DipSignupErrorDialog(
+    message: String,
+    confirmButtonMessage: String,
+    onConfirmCallback: () -> Unit,
+    onDismissCallback: (() -> Unit)? = null,
+) {
     AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = onConfirmCallback,
         title = {
             Text(
                 text = stringResource(id = R.string.something_went_wrong),
@@ -217,17 +258,28 @@ private fun DipSignupErrorDialog(onDismiss: () -> Unit) {
         },
         text = {
             Text(
-                text = stringResource(id = R.string.dip_signup_error),
+                text = message,
                 fontSize = 14.sp,
             )
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onConfirmCallback) {
                 Text(
-                    text = stringResource(id = R.string.take_me_back),
+                    text = confirmButtonMessage,
                     fontSize = 14.sp,
                     color = LocalColors.current.primary,
                 )
+            }
+        },
+        dismissButton = {
+            onDismissCallback?.let {
+                TextButton(onClick = it) {
+                    Text(
+                        text = stringResource(id = R.string.take_me_back),
+                        fontSize = 14.sp,
+                        color = LocalColors.current.primary,
+                    )
+                }
             }
         },
     )

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -1,5 +1,6 @@
 package com.kape.dedicatedip.ui.screens.mobile
 
+import android.app.Activity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -57,6 +58,7 @@ fun SignupDedicatedIpScreen() = Screen {
         getDipYearlyPlan()
     }
     val showSupportedCountriesDialog = remember { mutableStateOf(true) }
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -91,24 +93,28 @@ fun SignupDedicatedIpScreen() = Screen {
         }
         Spacer(modifier = Modifier.height(32.dp))
         YearlySubscriptionCard(
-            selected = true,
+            selected = viewModel.selectedPlanProductId.value == viewModel.dipYearlyPlan.value?.id,
             price = viewModel.dipYearlyPlan.value?.yearlyPrice.toString(),
             perMonthPrice = viewModel.dipYearlyPlan.value?.monthlyPrice.toString(),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            TODO()
+            viewModel.dipYearlyPlan.value?.let {
+                viewModel.selectedPlanProductId.value = it.id
+            }
         }
         Spacer(modifier = Modifier.height(16.dp))
         MonthlySubscriptionCard(
-            selected = false,
+            selected = viewModel.selectedPlanProductId.value == viewModel.dipMonthlyPlan.value?.id,
             price = viewModel.dipMonthlyPlan.value?.monthlyPrice.toString(),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            TODO()
+            viewModel.dipMonthlyPlan.value?.let {
+                viewModel.selectedPlanProductId.value = it.id
+            }
         }
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(
@@ -117,7 +123,7 @@ fun SignupDedicatedIpScreen() = Screen {
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            viewModel.navigateToDedicatedIpLocationSelection()
+            viewModel.purchaseSubscription(activity = context as Activity)
         }
         Spacer(modifier = Modifier.height(8.dp))
         SecondaryButton(

--- a/features/dedicatedip/src/test/java/com/kape/dedicatedip/data/DipDataSourceImplTest.kt
+++ b/features/dedicatedip/src/test/java/com/kape/dedicatedip/data/DipDataSourceImplTest.kt
@@ -27,6 +27,7 @@ class DipDataSourceImplTest {
 
     private val api: AndroidAccountAPI = mockk(relaxed = true)
     private val prefs: DipPrefs = mockk()
+    private val context: android.content.Context = mockk()
 
     private lateinit var source: DipDataSource
 
@@ -40,7 +41,7 @@ class DipDataSourceImplTest {
         startKoin {
             modules(appModule, dedicatedIpModule(appModule))
         }
-        source = DipDataSourceImpl(api, prefs)
+        source = DipDataSourceImpl(context, api, prefs)
     }
 
     @Test


### PR DESCRIPTION
## Summary

It introduces the logic of validating the purchase details with our API to confirm the purchase.

## Sanity Tests

- [x] Open the application. Perform a DIP purchase. Confirm we send all relevant details for confirmation to our API.