### PR TITLE
PIA-1946: Bump version to 4.0.8 (671)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,10 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-val googleAppVersionCode = 670
+val googleAppVersionCode = 671
 val amazonAppVersionCode = googleAppVersionCode.plus(10000)
 val noInAppVersionCode = googleAppVersionCode.plus(10000)
-val appVersionName = "4.0.7"
+val appVersionName = "4.0.8"
 
 android {
     namespace = "com.kape.vpn"


### PR DESCRIPTION
## Summary

As per title. It bumps de version name and code to `4.0.8` and `671` respectively.

## Sanity Tests

- [x] Run the charter. Confirm it succeeds. (There are two minor issues we will address in the next version).