### PR TITLE
PIA-1920: Introduce DIP signup error handling

### DIFF
--- a/capabilities/ui/src/main/res/values/strings.xml
+++ b/capabilities/ui/src/main/res/values/strings.xml
@@ -152,6 +152,8 @@
     <string name="dip_signup_banner_home_description">Would you like to add a Dedicated IP to your subscription?</string>
     <string name="dip_signup_banner_activate_description">Don\'t have a Dedicated IP token yet?</string>
     <string name="dip_signup_error">It looks like you subscribed on the PIA website and you cannot buy the add-on directly from here. Please return to the website and purchase your Dedicated IP add-on.</string>
+    <string name="dip_signup_required_information_missing_error">An error occurred when retrieving the required information. Please try again later.</string>
+    <string name="dip_signup_purchase_validation_error">An error occurred validating the purchase. You will not be charged until the validation is successful. Please try again.</string>
     <string name="dip_signup_supported_countries_title">You\'ll be able to select only one of the available locations below</string>
     <string name="dip_signup_banner_activate_benefit_one">Avoid CAPTCHAs</string>
     <string name="dip_signup_banner_activate_benefit_two">Avoid blocklists</string>

--- a/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
@@ -3,6 +3,7 @@ package com.kape.dip
 import android.content.Context
 import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.dip.data.DedicatedIpSignupPlans
+import com.kape.dip.data.DedicatedIpSupportedCountries
 import com.kape.utils.Prefs
 import com.privateinternetaccess.account.model.response.DedicatedIPInformationResponse
 import kotlinx.serialization.encodeToString
@@ -12,6 +13,7 @@ private const val DEDICATED_IPS = "dedicated-ips"
 private const val DIP_SIGNUP_ENABLED = "dip-signup-enabled"
 private const val DIP_SIGNUP_HOME_BANNER_VISIBLE = "dip-signup-home-banner-visible"
 private const val DIP_SIGNUP_PLANS = "dip-signup-plans"
+private const val DIP_SUPPORTED_COUNTRIES = "dip-supported-countries"
 private const val DIP_SIGNUP_PURCHASED_TOKEN = "dip-signup-purchased-token"
 
 class DipPrefs(
@@ -69,6 +71,20 @@ class DipPrefs(
 
     fun getDedicatedIpSignupPlans(): DedicatedIpSignupPlans? =
         prefs.getString(DIP_SIGNUP_PLANS, null)?.let {
+            Json.decodeFromString(it)
+        }
+
+    fun setDedicatedIpSupportedCountries(
+        dedicatedIpSupportedCountries: DedicatedIpSupportedCountries,
+    ) {
+        prefs.edit().putString(
+            DIP_SUPPORTED_COUNTRIES,
+            Json.encodeToString(dedicatedIpSupportedCountries),
+        ).apply()
+    }
+
+    fun getDedicatedIpSupportedCountries(): DedicatedIpSupportedCountries? =
+        prefs.getString(DIP_SUPPORTED_COUNTRIES, null)?.let {
             Json.decodeFromString(it)
         }
 

--- a/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSupportedCountries.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSupportedCountries.kt
@@ -1,0 +1,10 @@
+package com.kape.dip.data
+
+import com.privateinternetaccess.account.model.response.DipCountriesResponse
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DedicatedIpSupportedCountries(
+    val persistedTimestamp: Long,
+    val supportedCountries: DipCountriesResponse,
+)

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipSignupRepository.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/data/DipSignupRepository.kt
@@ -3,7 +3,9 @@ package com.kape.dedicatedip.data
 import com.kape.dedicatedip.domain.DipDataSource
 import com.kape.dip.DipPrefs
 import com.kape.dip.data.DedicatedIpSignupPlans
+import com.kape.dip.data.DedicatedIpSupportedCountries
 import com.privateinternetaccess.account.model.response.AndroidAddonsSubscriptionsInformation
+import com.privateinternetaccess.account.model.response.DipCountriesResponse
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -15,6 +17,7 @@ class DipSignupRepository(
 
     private companion object {
         private const val DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_1_DAY = 1L * 24 * 60 * 60 * 1000
+        private const val DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_12_HOURS = 1L * 12 * 60 * 60 * 1000
     }
 
     fun signupPlans(): Flow<AndroidAddonsSubscriptionsInformation?> = callbackFlow {
@@ -34,6 +37,23 @@ class DipSignupRepository(
         awaitClose { channel.close() }
     }
 
+    fun dipSupportedCountries(): Flow<DipCountriesResponse?> = callbackFlow {
+        dipPrefs.getDedicatedIpSupportedCountries()?.let {
+            if (System.currentTimeMillis() - it.persistedTimestamp > DIP_SIGNUP_FETCH_PLANS_MIN_CACHE_12_HOURS) {
+                fetchSupportedCountries().collect { fetchedSupportedCountries ->
+                    trySend(fetchedSupportedCountries)
+                }
+            } else {
+                trySend(it.supportedCountries)
+            }
+        } ?: run {
+            fetchSupportedCountries().collect {
+                trySend(it)
+            }
+        }
+        awaitClose { channel.close() }
+    }
+
     // region private
     private fun fetchSignupPlans(): Flow<AndroidAddonsSubscriptionsInformation?> = callbackFlow {
         dipDataSource.signupPlans().collect {
@@ -42,6 +62,21 @@ class DipSignupRepository(
                     dedicatedIpSignupPlans = DedicatedIpSignupPlans(
                         persistedTimestamp = System.currentTimeMillis(),
                         signupPlans = it,
+                    ),
+                )
+            }
+            trySend(it)
+        }
+        awaitClose { channel.close() }
+    }
+
+    private fun fetchSupportedCountries(): Flow<DipCountriesResponse?> = callbackFlow {
+        dipDataSource.supportedCountries().collect {
+            it?.let {
+                dipPrefs.setDedicatedIpSupportedCountries(
+                    dedicatedIpSupportedCountries = DedicatedIpSupportedCountries(
+                        persistedTimestamp = System.currentTimeMillis(),
+                        supportedCountries = it,
                     ),
                 )
             }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/GetDipSupportedCountries.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/GetDipSupportedCountries.kt
@@ -1,13 +1,16 @@
 package com.kape.dedicatedip.domain
 
+import com.kape.dedicatedip.data.DipSignupRepository
 import com.privateinternetaccess.account.model.response.DipCountriesResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class GetDipSupportedCountries(private val dataSource: DipDataSource) {
+class GetDipSupportedCountries(
+    private val dipSignupRepository: DipSignupRepository,
+) {
 
     operator fun invoke(): Flow<DipCountriesResponse?> = flow {
-        dataSource.supportedCountries().collect {
+        dipSignupRepository.dipSupportedCountries().collect {
             emit(it)
         }
     }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -61,7 +61,7 @@ fun SignupDedicatedIpCountryScreen() = Screen {
         appBarText(stringResource(id = R.string.dedicated_ip_title))
     }
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getSupportedDipCountries()
+        getDipSupportedCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()
     }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,8 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,11 +52,10 @@ import org.koin.androidx.compose.koinViewModel
 fun SignupDedicatedIpScreen() = Screen {
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
         hasActivePlaystoreSubscription()
-        getSupportedDipCountries()
+        getDipSupportedCountries()
         getDipMonthlyPlan()
         getDipYearlyPlan()
     }
-    val showSupportedCountriesDialog = remember { mutableStateOf(true) }
     val context = LocalContext.current
 
     Column(
@@ -76,84 +74,122 @@ fun SignupDedicatedIpScreen() = Screen {
                 .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Column {
-            DedicatedIpSignupTitleText(
-                content = stringResource(id = R.string.dip_signup_addon_title),
+        if (viewModel.showFetchingPlansSpinner.value || viewModel.showValidatingPurchaseSpinner.value) {
+            Column(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
+                    .fillMaxSize()
+                    .padding(bottom = 64.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.padding(8.dp))
+            }
+        } else {
+            Column {
+                DedicatedIpSignupTitleText(
+                    content = stringResource(id = R.string.dip_signup_addon_title),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                DedicatedIpSignupDescriptionText(
+                    content = stringResource(id = R.string.dip_signup_addon_description),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(horizontal = 16.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+            YearlySubscriptionCard(
+                selected = viewModel.selectedPlanProductId.value == viewModel.dipYearlyPlan.value?.id,
+                price = viewModel.dipYearlyPlan.value?.yearlyPrice.toString(),
+                perMonthPrice = viewModel.dipYearlyPlan.value?.monthlyPrice.toString(),
+                modifier = Modifier
+                    .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+            ) {
+                viewModel.dipYearlyPlan.value?.let {
+                    viewModel.selectedPlanProductId.value = it.id
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            MonthlySubscriptionCard(
+                selected = viewModel.selectedPlanProductId.value == viewModel.dipMonthlyPlan.value?.id,
+                price = viewModel.dipMonthlyPlan.value?.monthlyPrice.toString(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.dipMonthlyPlan.value?.let {
+                    viewModel.selectedPlanProductId.value = it.id
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            PrimaryButton(
+                text = stringResource(id = R.string.logjn_continue),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.purchaseSubscription(activity = context as Activity)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            SecondaryButton(
+                text = stringResource(id = R.string.cancel),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                viewModel.navigateBack()
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Footer(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally),
             )
             Spacer(modifier = Modifier.height(16.dp))
-            DedicatedIpSignupDescriptionText(
-                content = stringResource(id = R.string.dip_signup_addon_description),
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(horizontal = 16.dp),
-            )
         }
-        Spacer(modifier = Modifier.height(32.dp))
-        YearlySubscriptionCard(
-            selected = viewModel.selectedPlanProductId.value == viewModel.dipYearlyPlan.value?.id,
-            price = viewModel.dipYearlyPlan.value?.yearlyPrice.toString(),
-            perMonthPrice = viewModel.dipYearlyPlan.value?.monthlyPrice.toString(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.dipYearlyPlan.value?.let {
-                viewModel.selectedPlanProductId.value = it.id
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        MonthlySubscriptionCard(
-            selected = viewModel.selectedPlanProductId.value == viewModel.dipMonthlyPlan.value?.id,
-            price = viewModel.dipMonthlyPlan.value?.monthlyPrice.toString(),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.dipMonthlyPlan.value?.let {
-                viewModel.selectedPlanProductId.value = it.id
-            }
-        }
-        Spacer(modifier = Modifier.height(24.dp))
-        PrimaryButton(
-            text = stringResource(id = R.string.logjn_continue),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.purchaseSubscription(activity = context as Activity)
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        SecondaryButton(
-            text = stringResource(id = R.string.cancel),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            viewModel.navigateBack()
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        Spacer(modifier = Modifier.weight(1f))
-        Footer(
-            modifier = Modifier
-                .padding(16.dp)
-                .align(Alignment.CenterHorizontally),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
     }
 
     if (viewModel.hasAnActivePlaystoreSubscription.value) {
-        if (showSupportedCountriesDialog.value) {
+        if (viewModel.showSupportedCountriesDialog.value) {
             DipSignupSupportedCountriesDialog(viewModel = viewModel) {
-                showSupportedCountriesDialog.value = false
+                viewModel.showSupportedCountriesDialog.value = false
+            }
+        } else {
+            if (viewModel.showFetchingNeededInformationError.value) {
+                DipSignupErrorDialog(
+                    message = stringResource(id = R.string.dip_signup_required_information_missing_error),
+                    confirmButtonMessage = stringResource(id = R.string.take_me_back),
+                    onConfirmCallback = {
+                        viewModel.navigateBack()
+                    },
+                )
             }
         }
     } else {
-        DipSignupErrorDialog() {
-            viewModel.navigateBack()
-        }
+        DipSignupErrorDialog(
+            message = stringResource(id = R.string.dip_signup_error),
+            confirmButtonMessage = stringResource(id = R.string.take_me_back),
+            onConfirmCallback = {
+                viewModel.navigateBack()
+            },
+        )
+    }
+
+    if (viewModel.showPurchaseValidationError.value) {
+        DipSignupErrorDialog(
+            message = stringResource(id = R.string.dip_signup_purchase_validation_error),
+            confirmButtonMessage = stringResource(id = R.string.try_again),
+            onConfirmCallback = {
+                viewModel.validateSubscriptionPurchase()
+            },
+            onDismissCallback = {
+                viewModel.navigateBack()
+            },
+        )
     }
 }
 
@@ -205,9 +241,14 @@ private fun DipSignupSupportedCountriesDialog(
 }
 
 @Composable
-private fun DipSignupErrorDialog(onDismiss: () -> Unit) {
+fun DipSignupErrorDialog(
+    message: String,
+    confirmButtonMessage: String,
+    onConfirmCallback: () -> Unit,
+    onDismissCallback: (() -> Unit)? = null,
+) {
     AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = onConfirmCallback,
         title = {
             Text(
                 text = stringResource(id = R.string.something_went_wrong),
@@ -217,17 +258,28 @@ private fun DipSignupErrorDialog(onDismiss: () -> Unit) {
         },
         text = {
             Text(
-                text = stringResource(id = R.string.dip_signup_error),
+                text = message,
                 fontSize = 14.sp,
             )
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onConfirmCallback) {
                 Text(
-                    text = stringResource(id = R.string.take_me_back),
+                    text = confirmButtonMessage,
                     fontSize = 14.sp,
                     color = LocalColors.current.primary,
                 )
+            }
+        },
+        dismissButton = {
+            onDismissCallback?.let {
+                TextButton(onClick = it) {
+                    Text(
+                        text = stringResource(id = R.string.take_me_back),
+                        fontSize = 14.sp,
+                        color = LocalColors.current.primary,
+                    )
+                }
             }
         },
     )


### PR DESCRIPTION
## Summary

As per title. It introduces the error handling for the majority of cases. Those being:

- The Plans failed to be fetched for the first time.
- The list of supported countries failed to be fetched for the first time.
- The Billing library purchase failed.
- The confirmation of the purchase with our backend failed.

## Sanity Tests
_Done by mocking responses_

- [x] Open the app. Mock-fail the request to get the list of supported countries. Confirm we show an error and abort the purchase.
- [x] Open the app. Mock-fail the request to get the subscriptions. Confirm we show an error and abort the purchase.
- [x] Open the app. Mock-fail the billing library payment. Confirm we show an error and abort the purchase.
- [x] Open the app. Mock-fail the confirmation of purchase with our backend. Confirm we show an error and abort the purchase.