### PR TITLE
PIA-1948: Move DIP signup purchase logic to the region selection screen

### DIFF
--- a/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
@@ -15,6 +15,7 @@ private const val DIP_SIGNUP_HOME_BANNER_VISIBLE = "dip-signup-home-banner-visib
 private const val DIP_SIGNUP_PLANS = "dip-signup-plans"
 private const val DIP_SUPPORTED_COUNTRIES = "dip-supported-countries"
 private const val DIP_SIGNUP_PURCHASED_TOKEN = "dip-signup-purchased-token"
+private const val DIP_SIGNUP_SELECTED_PRODUCT_ID = "dip-signup-selected-product-id"
 
 class DipPrefs(
     context: Context,
@@ -87,6 +88,16 @@ class DipPrefs(
         prefs.getString(DIP_SUPPORTED_COUNTRIES, null)?.let {
             Json.decodeFromString(it)
         }
+
+    fun setSelectedDipSignupProductId(productId: String) {
+        prefs.edit().putString(
+            DIP_SIGNUP_SELECTED_PRODUCT_ID,
+            productId,
+        ).apply()
+    }
+
+    fun getSelectedDipSignupProductId(): String =
+        prefs.getString(DIP_SIGNUP_SELECTED_PRODUCT_ID, "") ?: ""
 
     private fun getDips() = prefs.getStringSet(DEDICATED_IPS, emptySet()) ?: emptySet()
 

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -1,10 +1,12 @@
 package com.kape.dedicatedip.ui.screens.mobile
 
+import android.app.Activity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -22,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -69,97 +72,140 @@ fun SignupDedicatedIpCountryScreen() = Screen {
 
     val showAllLocations = remember { mutableStateOf(false) }
 
-    Scaffold(
-        topBar = {
-            AppBar(
-                viewModel = appBarViewModel,
-                onLeftIconClick = { viewModel.navigateBack() },
-            )
-        },
-    ) {
+    if (viewModel.showValidatingPurchaseSpinner.value) {
         Column(
             modifier = Modifier
-                .padding(it)
-                .verticalScroll(rememberScrollState())
-                .fillMaxSize(),
+                .padding(8.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(modifier = Modifier.height(40.dp))
-            DedicatedIpSignupCountryTitleText(
-                stringResource(id = R.string.dip_signup_country_title),
-                Modifier.padding(horizontal = 16.dp),
-            )
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Box(
+            Icon(
+                painter = painterResource(id = R.drawable.ic_dip),
+                tint = LocalColors.current.primary,
+                contentDescription = null,
                 modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .border(
-                        0.5.dp,
-                        LocalColors.current.outlineVariant,
-                        shape = RoundedCornerShape(12.dp),
-                    )
-                    .background(
-                        LocalColors.current.onPrimary,
-                        shape = RoundedCornerShape(12.dp),
-                    ),
+                    .padding(16.dp)
+                    .height(40.dp)
+                    .fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 64.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
             ) {
-                viewModel.dipSelectedCountry.value?.let { dedicatedIpSelectedCountry ->
-                    DipCountryItem(dedicatedIpSelectedCountry) {
-                        showAllLocations.value = !showAllLocations.value
-                    }
-                }
-                Icon(
-                    painter = painterResource(R.drawable.ic_chevron_down),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 16.dp),
-                )
+                CircularProgressIndicator(modifier = Modifier.padding(8.dp))
             }
+        }
+    } else {
+        Scaffold(
+            topBar = {
+                AppBar(
+                    viewModel = appBarViewModel,
+                    onLeftIconClick = { viewModel.navigateBack() },
+                )
+            },
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(it)
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxSize(),
+            ) {
+                Spacer(modifier = Modifier.height(40.dp))
+                DedicatedIpSignupCountryTitleText(
+                    stringResource(id = R.string.dip_signup_country_title),
+                    Modifier.padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(20.dp))
 
-            if (showAllLocations.value) {
-                Spacer(modifier = Modifier.height(16.dp))
-                Card(
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    border = BorderStroke(1.dp, LocalColors.current.onPrimary),
+                        .padding(horizontal = 16.dp)
+                        .border(
+                            0.5.dp,
+                            LocalColors.current.outlineVariant,
+                            shape = RoundedCornerShape(12.dp),
+                        )
+                        .background(
+                            LocalColors.current.onPrimary,
+                            shape = RoundedCornerShape(12.dp),
+                        ),
                 ) {
-                    viewModel.supportedDipCountriesList.value?.let {
-                        FlowColumn {
-                            it.dedicatedIpCountriesAvailable.forEach { country ->
-                                DipCountryItem(country = country) { dedicatedIpSelectedCountry ->
-                                    viewModel.selectDipCountry(dedicatedIpSelectedCountry)
-                                    showAllLocations.value = !showAllLocations.value
+                    viewModel.dipSelectedCountry.value?.let { dedicatedIpSelectedCountry ->
+                        DipCountryItem(dedicatedIpSelectedCountry) {
+                            showAllLocations.value = !showAllLocations.value
+                        }
+                    }
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron_down),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 16.dp),
+                    )
+                }
+
+                if (showAllLocations.value) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        border = BorderStroke(1.dp, LocalColors.current.onPrimary),
+                    ) {
+                        viewModel.supportedDipCountriesList.value?.let {
+                            FlowColumn {
+                                it.dedicatedIpCountriesAvailable.forEach { country ->
+                                    DipCountryItem(country = country) { dedicatedIpSelectedCountry ->
+                                        viewModel.selectDipCountry(dedicatedIpSelectedCountry)
+                                        showAllLocations.value = !showAllLocations.value
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
 
-            Spacer(modifier = Modifier.height(16.dp))
-            DedicatedIpSignupCountryDisclaimerText(
-                stringResource(id = R.string.dip_signup_country_disclaimer),
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            )
-            if (showAllLocations.value) {
-                BottomScreen(showAllLocations = showAllLocations.value, viewModel = viewModel)
+                Spacer(modifier = Modifier.height(16.dp))
+                DedicatedIpSignupCountryDisclaimerText(
+                    stringResource(id = R.string.dip_signup_country_disclaimer),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+                if (showAllLocations.value) {
+                    BottomScreen(showAllLocations = showAllLocations.value, viewModel = viewModel)
+                }
+            }
+            Column {
+                if (!showAllLocations.value) {
+                    BottomScreen(showAllLocations = showAllLocations.value, viewModel = viewModel)
+                }
             }
         }
-        Column {
-            if (!showAllLocations.value) {
-                BottomScreen(showAllLocations = showAllLocations.value, viewModel = viewModel)
-            }
-        }
+    }
+
+    if (viewModel.showPurchaseValidationError.value) {
+        DipSignupErrorDialog(
+            message = stringResource(id = R.string.dip_signup_purchase_validation_error),
+            confirmButtonMessage = stringResource(id = R.string.try_again),
+            onConfirmCallback = {
+                viewModel.validateSubscriptionPurchase()
+            },
+            onDismissCallback = {
+                viewModel.navigateBack()
+            },
+        )
     }
 }
 
 @Composable
 fun BottomScreen(showAllLocations: Boolean, viewModel: DipViewModel) {
+    val context = LocalContext.current
     Column(
         modifier = Modifier
             .padding(8.dp),
@@ -174,7 +220,7 @@ fun BottomScreen(showAllLocations: Boolean, viewModel: DipViewModel) {
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            viewModel.navigateToDedicatedIpTokenDetails()
+            viewModel.purchaseSubscription(context as Activity)
         }
         Spacer(modifier = Modifier.height(8.dp))
         SecondaryButton(

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -1,6 +1,5 @@
 package com.kape.dedicatedip.ui.screens.mobile
 
-import android.app.Activity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -56,7 +55,6 @@ fun SignupDedicatedIpScreen() = Screen {
         getDipMonthlyPlan()
         getDipYearlyPlan()
     }
-    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -74,7 +72,7 @@ fun SignupDedicatedIpScreen() = Screen {
                 .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(16.dp))
-        if (viewModel.showFetchingPlansSpinner.value || viewModel.showValidatingPurchaseSpinner.value) {
+        if (viewModel.showFetchingPlansSpinner.value) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -110,7 +108,7 @@ fun SignupDedicatedIpScreen() = Screen {
                     .padding(horizontal = 16.dp),
             ) {
                 viewModel.dipYearlyPlan.value?.let {
-                    viewModel.selectedPlanProductId.value = it.id
+                    viewModel.selectPlanProductId(it.id)
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
@@ -122,7 +120,7 @@ fun SignupDedicatedIpScreen() = Screen {
                     .padding(horizontal = 16.dp),
             ) {
                 viewModel.dipMonthlyPlan.value?.let {
-                    viewModel.selectedPlanProductId.value = it.id
+                    viewModel.selectPlanProductId(it.id)
                 }
             }
             Spacer(modifier = Modifier.height(24.dp))
@@ -132,7 +130,7 @@ fun SignupDedicatedIpScreen() = Screen {
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
             ) {
-                viewModel.purchaseSubscription(activity = context as Activity)
+                viewModel.navigateToDedicatedIpLocationSelection()
             }
             Spacer(modifier = Modifier.height(8.dp))
             SecondaryButton(
@@ -174,19 +172,6 @@ fun SignupDedicatedIpScreen() = Screen {
             message = stringResource(id = R.string.dip_signup_error),
             confirmButtonMessage = stringResource(id = R.string.take_me_back),
             onConfirmCallback = {
-                viewModel.navigateBack()
-            },
-        )
-    }
-
-    if (viewModel.showPurchaseValidationError.value) {
-        DipSignupErrorDialog(
-            message = stringResource(id = R.string.dip_signup_purchase_validation_error),
-            confirmButtonMessage = stringResource(id = R.string.try_again),
-            onConfirmCallback = {
-                viewModel.validateSubscriptionPurchase()
-            },
-            onDismissCallback = {
                 viewModel.navigateBack()
             },
         )

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
@@ -57,7 +57,7 @@ class DipViewModel(
     val supportedDipCountriesList = mutableStateOf<DipCountriesResponse?>(null)
     val dipMonthlyPlan = mutableStateOf<DedicatedIpMonthlyPlan?>(null)
     val dipYearlyPlan = mutableStateOf<DedicatedIpYearlyPlan?>(null)
-    val selectedPlanProductId = mutableStateOf("")
+    val selectedPlanProductId = mutableStateOf(dipPrefs.getSelectedDipSignupProductId())
     val dipSelectedCountry = mutableStateOf<DedicatedIpSelectedCountry?>(null)
     val showSupportedCountriesDialog = mutableStateOf(true)
     val showFetchingNeededInformationError = mutableStateOf(false)
@@ -186,8 +186,8 @@ class DipViewModel(
             showFetchingNeededInformationError.value =
                 dipMonthlyPlan.value == null && yearlyPlan == null
             yearlyPlan?.let {
-                if (selectedPlanProductId.value.isEmpty()) {
-                    selectedPlanProductId.value = it.id
+                if (dipPrefs.getSelectedDipSignupProductId().isEmpty()) {
+                    selectPlanProductId(it.id)
                 }
                 dipYearlyPlan.value = it
                 showFetchingPlansSpinner.value = false
@@ -208,6 +208,11 @@ class DipViewModel(
         dipSelectedCountry.value = selected
     }
 
+    fun selectPlanProductId(productId: String) {
+        dipPrefs.setSelectedDipSignupProductId(productId)
+        selectedPlanProductId.value = dipPrefs.getSelectedDipSignupProductId()
+    }
+
     fun enableActivateTokenButton() {
         activateTokenButtonState.value = true
     }
@@ -216,13 +221,13 @@ class DipViewModel(
         getSignupDipToken.invoke()
 
     fun purchaseSubscription(activity: Activity) {
-        if (selectedPlanProductId.value.isEmpty()) {
+        if (dipPrefs.getSelectedDipSignupProductId().isEmpty()) {
             return
         }
 
         dipSubscriptionPaymentProvider.purchaseProduct(
             activity = activity,
-            productId = selectedPlanProductId.value,
+            productId = dipPrefs.getSelectedDipSignupProductId(),
         ) { result ->
             result.fold(
                 onSuccess = {


### PR DESCRIPTION
## Summary

It moves the logic triggering the DIP purchase to the screen selecting the region as per the specs.

## Sanity Tests

- [x] Open feature. Select yearly. Tap continue. Select region. Tap continue. Approve the purchase and confirm the yearly subscription.
- [x] Open feature. Select monthly. Tap continue. Select region. Tap continue. Approve the purchase and confirm the monthly subscription.
- [x] Mocking a purchase validation failure. Tap continue. Select region. Tap continue. Approve the purchase. Confirm purchase validation error with try again and go back options. Tap try again. Confirm it tries to validate again. Tap go back. Confirm we go back.