### PR TITLE
PIA-1955: Update DIP token details logic to detect screenshots to backup information

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
     <!--Android 14-->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" />
 
     <uses-feature
         android:name="android.software.leanback"

--- a/capabilities/ui/src/main/res/values/strings.xml
+++ b/capabilities/ui/src/main/res/values/strings.xml
@@ -167,9 +167,8 @@
     <string name="dip_signup_purchase_success_description">You can now activate your Dedicated IP with the generated token at the next screen.</string>
     <string name="dip_signup_save_your_token_title">Save your token</string>
     <string name="dip_signup_save_your_token_description">This is your only one-time show token to activate your Dedicated IP.</string>
-    <string name="dip_signup_save_your_token_footer_start">Screenshot or save your token for use on other devices.</string>
+    <string name="dip_signup_save_your_token_footer_start">Screenshot your token as a backup for use on other devices.</string>
     <string name="dip_signup_save_your_token_footer_end">If you lose your token, you will need to repurchase a Dedicated IP.</string>
-    <string name="dip_signup_save_your_token_as_pdf">Save token as PDF</string>
     <string name="dip_signup_token_copied">Token copied to your clipboard</string>
     <string name="dip_signup_activate_token">Activate token</string>
     <string name="dip_signup_activate_token_description">Activate your Dedicated IP by pasting your token in the form below. If you\'ve recently purchased a Dedicated IP, you can generate the token by going to the PIA website.</string>

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/di/DipModule.kt
@@ -8,6 +8,7 @@ import com.kape.dedicatedip.domain.FetchSignupDipToken
 import com.kape.dedicatedip.domain.GetDipMonthlyPlan
 import com.kape.dedicatedip.domain.GetDipSupportedCountries
 import com.kape.dedicatedip.domain.GetDipYearlyPlan
+import com.kape.dedicatedip.domain.ObserveScreenCaptureUseCase
 import com.kape.dedicatedip.domain.RenewDipUseCase
 import com.kape.dedicatedip.domain.ValidateDipSignup
 import com.kape.dedicatedip.ui.vm.DipViewModel
@@ -33,7 +34,8 @@ val localDipModule = module {
     single { GetDipYearlyPlan(get(), get(), get()) }
     single { ValidateDipSignup(get(), get()) }
     single { FetchSignupDipToken(get()) }
+    single { ObserveScreenCaptureUseCase() }
     viewModel {
-        DipViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+        DipViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
     }
 }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/ObserveScreenCaptureUseCase.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/domain/ObserveScreenCaptureUseCase.kt
@@ -1,0 +1,16 @@
+package com.kape.dedicatedip.domain
+
+class ObserveScreenCaptureUseCase {
+
+    private val callbacks = mutableSetOf<(() -> Unit)>()
+
+    fun registerCallback(callback: () -> Unit) {
+        callbacks.add(callback)
+    }
+
+    fun announce() {
+        callbacks.forEach {
+            it()
+        }
+    }
+}

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenDetailsScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenDetailsScreen.kt
@@ -31,7 +31,6 @@ import com.kape.dedicatedip.ui.vm.DipViewModel
 import com.kape.ui.R
 import com.kape.ui.mobile.elements.PrimaryButton
 import com.kape.ui.mobile.elements.Screen
-import com.kape.ui.mobile.elements.SecondaryButton
 import com.kape.ui.mobile.text.DedicatedIpSignupActivateTokenDescriptionText
 import com.kape.ui.mobile.text.DedicatedIpSignupActivateTokenFooter
 import com.kape.ui.mobile.text.DedicatedIpSignupActivateTokenTitleText
@@ -55,6 +54,10 @@ fun SignupDedicatedIpTokenDetailsScreen() = Screen {
         withStyle(style = SpanStyle(color = LocalColors.current.connectionError())) {
             append(" ${stringResource(id = R.string.dip_signup_save_your_token_footer_end)}")
         }
+    }
+
+    viewModel.registerScreenCaptureCallback {
+        viewModel.enableActivateTokenButton()
     }
 
     Column(
@@ -135,13 +138,6 @@ fun SignupDedicatedIpTokenDetailsScreen() = Screen {
                             tint = LocalColors.current.infoBlue(),
                         )
                     }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-                SecondaryButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(id = R.string.dip_signup_save_your_token_as_pdf),
-                ) {
-                    viewModel.enableActivateTokenButton()
                 }
                 Spacer(modifier = Modifier.height(16.dp))
                 DedicatedIpSignupActivateTokenFooter(

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
@@ -15,6 +15,7 @@ import com.kape.dedicatedip.domain.FetchSignupDipToken
 import com.kape.dedicatedip.domain.GetDipMonthlyPlan
 import com.kape.dedicatedip.domain.GetDipSupportedCountries
 import com.kape.dedicatedip.domain.GetDipYearlyPlan
+import com.kape.dedicatedip.domain.ObserveScreenCaptureUseCase
 import com.kape.dedicatedip.domain.ValidateDipSignup
 import com.kape.dedicatedip.utils.DedicatedIpStep
 import com.kape.dedicatedip.utils.DipApiResult
@@ -40,6 +41,7 @@ class DipViewModel(
     private val getDipYearlyPlan: GetDipYearlyPlan,
     private val validateDipSignup: ValidateDipSignup,
     private val fetchSignupDipToken: FetchSignupDipToken,
+    private val observeScreenCaptureUseCase: ObserveScreenCaptureUseCase,
     private val vpnSubscriptionPaymentProvider: VpnSubscriptionPaymentProvider,
     private val dipSubscriptionPaymentProvider: DipSubscriptionPaymentProvider,
     private val dipPrefs: DipPrefs,
@@ -106,6 +108,10 @@ class DipViewModel(
 
     fun navigateToDedicatedIpLocationSelection() = viewModelScope.launch {
         _state.emit(DedicatedIpStep.LocationSelection)
+    }
+
+    fun registerScreenCaptureCallback(callback: () -> Unit) {
+        observeScreenCaptureUseCase.registerCallback(callback)
     }
 
     fun loadDedicatedIps(locale: String) = viewModelScope.launch {


### PR DESCRIPTION
## Summary

It updates the DIP token details screen logic to enable the "Continue" button after either the user has copied the token details to the clipboard, or taken a screenshot of it. This is because we don't know any token details, and we need to make sure users back them up for future use.

## Sanity Tests

- [x] Navigate to token details. Confirm the "Continue" button is disabled. Tap to copy the token to the clipboard. Confirm the "Continue" button is enabled.
- [x] Navigate to token details. Confirm the "Continue" button is disabled. Screenshot the screen with the details. Confirm the "Continue" button is enabled.