### PR TITLE
PIA-1959: Fix DIP signup loading spinner not showing when retrying, and wrong location being sent to the API

### DIFF
--- a/capabilities/ui/src/main/java/com/kape/ui/mobile/text/Input.kt
+++ b/capabilities/ui/src/main/java/com/kape/ui/mobile/text/Input.kt
@@ -26,6 +26,7 @@ import com.kape.ui.utils.LocalColors
 @Composable
 fun Input(
     modifier: Modifier,
+    enabled: Boolean = true,
     label: String? = null,
     maskInput: Boolean,
     singleLine: Boolean = false,
@@ -49,6 +50,7 @@ fun Input(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth(),
+            enabled = enabled,
             value = content.value,
             onValueChange = {
                 content.value = it

--- a/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/DipPrefs.kt
@@ -2,6 +2,7 @@ package com.kape.dip
 
 import android.content.Context
 import com.kape.buildconfig.data.BuildConfigProvider
+import com.kape.dip.data.DedicatedIpSelectedCountry
 import com.kape.dip.data.DedicatedIpSignupPlans
 import com.kape.dip.data.DedicatedIpSupportedCountries
 import com.kape.utils.Prefs
@@ -16,6 +17,7 @@ private const val DIP_SIGNUP_PLANS = "dip-signup-plans"
 private const val DIP_SUPPORTED_COUNTRIES = "dip-supported-countries"
 private const val DIP_SIGNUP_PURCHASED_TOKEN = "dip-signup-purchased-token"
 private const val DIP_SIGNUP_SELECTED_PRODUCT_ID = "dip-signup-selected-product-id"
+private const val DIP_SIGNUP_SELECTED_COUNTRY = "dip-signup-selected-country"
 
 class DipPrefs(
     context: Context,
@@ -95,6 +97,18 @@ class DipPrefs(
             productId,
         ).apply()
     }
+
+    fun setDedicatedIpSelectedCountry(dedicatedIpSelectedCountry: DedicatedIpSelectedCountry) {
+        prefs.edit().putString(
+            DIP_SIGNUP_SELECTED_COUNTRY,
+            Json.encodeToString(dedicatedIpSelectedCountry),
+        ).apply()
+    }
+
+    fun getDedicatedIpSelectedCountry(): DedicatedIpSelectedCountry? =
+        prefs.getString(DIP_SIGNUP_SELECTED_COUNTRY, null)?.let {
+            Json.decodeFromString(it)
+        }
 
     fun getSelectedDipSignupProductId(): String =
         prefs.getString(DIP_SIGNUP_SELECTED_PRODUCT_ID, "") ?: ""

--- a/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSelectedCountry.kt
+++ b/core/localprefs/dip/src/main/java/com/kape/dip/data/DedicatedIpSelectedCountry.kt
@@ -1,5 +1,8 @@
-package com.kape.dedicatedip.data.models
+package com.kape.dip.data
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DedicatedIpSelectedCountry(
     val countryCode: String,
     val countryName: String,

--- a/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
+++ b/core/localprefs/payments/src/main/java/com/kape/payments/SubscriptionPrefs.kt
@@ -5,6 +5,7 @@ import com.kape.payments.data.DipPurchaseData
 import com.kape.payments.data.PurchaseData
 import com.kape.payments.data.Subscription
 import com.kape.utils.Prefs
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 private const val AVAILABLE_VPN_SUBSCRIPTIONS = "available-subscriptions"
@@ -45,7 +46,7 @@ class SubscriptionPrefs(context: Context) : Prefs(context, "subscriptions") {
     }
 
     fun storeDipPurchaseData(purchaseData: DipPurchaseData) {
-        prefs.edit().putString(DIP_PURCHASE_DATA, purchaseData.toString()).apply()
+        prefs.edit().putString(DIP_PURCHASE_DATA, Json.encodeToString(purchaseData)).apply()
     }
 
     fun getDipPurchaseData(): DipPurchaseData? =

--- a/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -16,6 +16,13 @@ class DipSubscriptionPaymentProviderImpl(
         callback(Result.failure(IllegalStateException("Unsupported")))
     }
 
+    override fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
+    ) {
+        callback(Result.failure(IllegalStateException("Unsupported")))
+    }
+
     override fun purchaseProduct(
         activity: Activity,
         productId: String,

--- a/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
+++ b/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
@@ -6,7 +6,7 @@ import com.kape.payments.data.DipPurchaseData
 interface DipSubscriptionPaymentProvider {
 
     /**
-     * It queries the productIds against those known by the billing library and returns the known
+     * It queries the productIds against those known by the billing library, and returns the known
      * ones, along with their formatted price.
      *
      * The first parameter of the pair is the product id.
@@ -18,6 +18,22 @@ interface DipSubscriptionPaymentProvider {
     fun productsDetails(
         productIds: List<String>,
         callback: (result: Result<List<Pair<String, String>>>) -> Unit,
+    )
+
+    /**
+     * It queries the productIds against those known by the billing library, and returns those
+     * that are known but have NOT been acknowledged, in order to resume a potentially interrupted
+     * purchase flow.
+     *
+     * The first parameter of the pair is the product id.
+     * The second parameter is the formatted price.
+     *
+     * @param productIds
+     * @param callback
+     */
+    fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
     )
 
     /**

--- a/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -16,6 +16,13 @@ class DipSubscriptionPaymentProviderImpl(
         callback(Result.failure(IllegalStateException("Unsupported")))
     }
 
+    override fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
+    ) {
+        callback(Result.failure(IllegalStateException("Unsupported")))
+    }
+
     override fun purchaseProduct(
         activity: Activity,
         productId: String,

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -58,7 +57,6 @@ import com.kape.appbar.viewmodel.AppBarViewModel
 import com.kape.dedicatedip.R
 import com.kape.dedicatedip.ui.vm.DipViewModel
 import com.kape.dedicatedip.utils.DipApiResult
-import com.kape.ui.mobile.elements.RoundIconButton
 import com.kape.ui.mobile.elements.Screen
 import com.kape.ui.mobile.elements.SecondaryButton
 import com.kape.ui.mobile.elements.Separator
@@ -187,9 +185,6 @@ fun DedicatedIpScreen() = Screen {
                         DedicatedIpSignupBanner(
                             onAcceptTapped = {
                                 viewModel.navigateToDedicatedIpPlans()
-                            },
-                            onDismissTapped = {
-                                TODO("To be implemented")
                             },
                         )
                     }
@@ -422,10 +417,7 @@ fun DeleteDipDialog(
 }
 
 @Composable
-fun DedicatedIpSignupBanner(
-    onAcceptTapped: () -> Unit,
-    onDismissTapped: () -> Unit,
-) {
+fun DedicatedIpSignupBanner(onAcceptTapped: () -> Unit) {
     Spacer(modifier = Modifier.height(16.dp))
     Card(
         border = BorderStroke(1.dp, color = LocalColors.current.onPrimaryContainer),
@@ -447,13 +439,6 @@ fun DedicatedIpSignupBanner(
                     contentDescription = null,
                 )
                 Spacer(modifier = Modifier.weight(1.0f))
-                RoundIconButton(
-                    painterId = com.kape.ui.R.drawable.ic_close,
-                    iconButtonColors = IconButtonDefaults.iconButtonColors(
-                        contentColor = LocalColors.current.onSurface,
-                    ),
-                    onClick = onDismissTapped,
-                )
             }
             Text(
                 modifier = Modifier

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.kape.appbar.view.mobile.AppBar
 import com.kape.appbar.viewmodel.AppBarViewModel
-import com.kape.dedicatedip.data.models.DedicatedIpSelectedCountry
 import com.kape.dedicatedip.ui.vm.DipViewModel
+import com.kape.dip.data.DedicatedIpSelectedCountry
 import com.kape.ui.R
 import com.kape.ui.mobile.elements.Footer
 import com.kape.ui.mobile.elements.PrimaryButton
@@ -134,7 +134,7 @@ fun SignupDedicatedIpCountryScreen() = Screen {
                             shape = RoundedCornerShape(12.dp),
                         ),
                 ) {
-                    viewModel.dipSelectedCountry.value?.let { dedicatedIpSelectedCountry ->
+                    viewModel.getSelectedDipCountry()?.let { dedicatedIpSelectedCountry ->
                         DipCountryItem(dedicatedIpSelectedCountry) {
                             showAllLocations.value = !showAllLocations.value
                         }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -64,10 +65,13 @@ fun SignupDedicatedIpCountryScreen() = Screen {
     val appBarViewModel: AppBarViewModel = koinViewModel<AppBarViewModel>().apply {
         appBarText(stringResource(id = R.string.dedicated_ip_title))
     }
-    val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getDipSupportedCountries()
-        getDipMonthlyPlan()
-        getDipYearlyPlan()
+    val viewModel: DipViewModel = koinViewModel()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.getDipSupportedCountries()
+        viewModel.getDipMonthlyPlan()
+        viewModel.getDipYearlyPlan()
+        viewModel.resumePossibleUnacknowledgedDipPurchases()
     }
 
     val showAllLocations = remember { mutableStateOf(false) }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,11 +50,13 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SignupDedicatedIpScreen() = Screen {
-    val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        hasActivePlaystoreSubscription()
-        getDipSupportedCountries()
-        getDipMonthlyPlan()
-        getDipYearlyPlan()
+    val viewModel: DipViewModel = koinViewModel()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.hasActivePlaystoreSubscription()
+        viewModel.getDipSupportedCountries()
+        viewModel.getDipMonthlyPlan()
+        viewModel.getDipYearlyPlan()
     }
 
     Column(

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenActivateScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenActivateScreen.kt
@@ -70,6 +70,7 @@ fun SignupDedicatedIpTokenActivateScreen() = Screen {
             Spacer(modifier = Modifier.height(16.dp))
             Input(
                 modifier = Modifier.fillMaxWidth(),
+                enabled = false,
                 maskInput = false,
                 keyboard = KeyboardType.Text,
                 content = dipToken,
@@ -114,7 +115,9 @@ fun SignupDedicatedIpTokenActivateScreen() = Screen {
                 .padding(horizontal = 16.dp),
         ) {
             showSpinner.value = true
-            viewModel.activateDedicatedIp(mutableStateOf(TextFieldValue(dipToken.value)))
+            viewModel.activateDedicatedIp(
+                mutableStateOf(TextFieldValue(viewModel.getSignupDipToken())),
+            )
         }
         Spacer(modifier = Modifier.height(64.dp))
     }


### PR DESCRIPTION
## Summary

- It fixes an issue where the loading spinner was not being shown after tapping "try again" as the dialog was not being dismissed.
- It fixes an issue where we were always sending the first location to the API due to the screen recomposition resetting the state of the selected region.

## Sanity Tests

- [x] Mocking a failure. Purchase a subscription. When the error dialog appears. Tap "Try again". Confirm the dialog disappears and we show the spinner momentarily due to the new attempt.
- [x] Purchase multiple subscriptions (by purchasing, and canceling). Selecting a different region each time. Confirm we always send the selected region information.