### PR TITLE
PIA-1921: Introduce DIP signup resuming of unacknowledged purchase

### DIFF
--- a/capabilities/ui/src/main/java/com/kape/ui/mobile/text/Input.kt
+++ b/capabilities/ui/src/main/java/com/kape/ui/mobile/text/Input.kt
@@ -26,6 +26,7 @@ import com.kape.ui.utils.LocalColors
 @Composable
 fun Input(
     modifier: Modifier,
+    enabled: Boolean = true,
     label: String? = null,
     maskInput: Boolean,
     singleLine: Boolean = false,
@@ -49,6 +50,7 @@ fun Input(
         OutlinedTextField(
             modifier = Modifier
                 .fillMaxWidth(),
+            enabled = enabled,
             value = content.value,
             onValueChange = {
                 content.value = it

--- a/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/amazon/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -16,6 +16,13 @@ class DipSubscriptionPaymentProviderImpl(
         callback(Result.failure(IllegalStateException("Unsupported")))
     }
 
+    override fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
+    ) {
+        callback(Result.failure(IllegalStateException("Unsupported")))
+    }
+
     override fun purchaseProduct(
         activity: Activity,
         productId: String,

--- a/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
+++ b/core/payments/src/main/java/com/kape/payments/ui/DipSubscriptionPaymentProvider.kt
@@ -6,7 +6,7 @@ import com.kape.payments.data.DipPurchaseData
 interface DipSubscriptionPaymentProvider {
 
     /**
-     * It queries the productIds against those known by the billing library and returns the known
+     * It queries the productIds against those known by the billing library, and returns the known
      * ones, along with their formatted price.
      *
      * The first parameter of the pair is the product id.
@@ -18,6 +18,22 @@ interface DipSubscriptionPaymentProvider {
     fun productsDetails(
         productIds: List<String>,
         callback: (result: Result<List<Pair<String, String>>>) -> Unit,
+    )
+
+    /**
+     * It queries the productIds against those known by the billing library, and returns those
+     * that are known but have NOT been acknowledged, in order to resume a potentially interrupted
+     * purchase flow.
+     *
+     * The first parameter of the pair is the product id.
+     * The second parameter is the formatted price.
+     *
+     * @param productIds
+     * @param callback
+     */
+    fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
     )
 
     /**

--- a/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
+++ b/core/payments/src/noinapp/java/com/kape/payments/ui/DipSubscriptionPaymentProviderImpl.kt
@@ -16,6 +16,13 @@ class DipSubscriptionPaymentProviderImpl(
         callback(Result.failure(IllegalStateException("Unsupported")))
     }
 
+    override fun unacknowledgedProductIds(
+        productIds: List<String>,
+        callback: (result: Result<List<String>>) -> Unit,
+    ) {
+        callback(Result.failure(IllegalStateException("Unsupported")))
+    }
+
     override fun purchaseProduct(
         activity: Activity,
         productId: String,

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -58,7 +57,6 @@ import com.kape.appbar.viewmodel.AppBarViewModel
 import com.kape.dedicatedip.R
 import com.kape.dedicatedip.ui.vm.DipViewModel
 import com.kape.dedicatedip.utils.DipApiResult
-import com.kape.ui.mobile.elements.RoundIconButton
 import com.kape.ui.mobile.elements.Screen
 import com.kape.ui.mobile.elements.SecondaryButton
 import com.kape.ui.mobile.elements.Separator
@@ -187,9 +185,6 @@ fun DedicatedIpScreen() = Screen {
                         DedicatedIpSignupBanner(
                             onAcceptTapped = {
                                 viewModel.navigateToDedicatedIpPlans()
-                            },
-                            onDismissTapped = {
-                                TODO("To be implemented")
                             },
                         )
                     }
@@ -422,10 +417,7 @@ fun DeleteDipDialog(
 }
 
 @Composable
-fun DedicatedIpSignupBanner(
-    onAcceptTapped: () -> Unit,
-    onDismissTapped: () -> Unit,
-) {
+fun DedicatedIpSignupBanner(onAcceptTapped: () -> Unit) {
     Spacer(modifier = Modifier.height(16.dp))
     Card(
         border = BorderStroke(1.dp, color = LocalColors.current.onPrimaryContainer),
@@ -447,13 +439,6 @@ fun DedicatedIpSignupBanner(
                     contentDescription = null,
                 )
                 Spacer(modifier = Modifier.weight(1.0f))
-                RoundIconButton(
-                    painterId = com.kape.ui.R.drawable.ic_close,
-                    iconButtonColors = IconButtonDefaults.iconButtonColors(
-                        contentColor = LocalColors.current.onSurface,
-                    ),
-                    onClick = onDismissTapped,
-                )
             }
             Text(
                 modifier = Modifier

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpCountryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -64,10 +65,13 @@ fun SignupDedicatedIpCountryScreen() = Screen {
     val appBarViewModel: AppBarViewModel = koinViewModel<AppBarViewModel>().apply {
         appBarText(stringResource(id = R.string.dedicated_ip_title))
     }
-    val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        getDipSupportedCountries()
-        getDipMonthlyPlan()
-        getDipYearlyPlan()
+    val viewModel: DipViewModel = koinViewModel()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.getDipSupportedCountries()
+        viewModel.getDipMonthlyPlan()
+        viewModel.getDipYearlyPlan()
+        viewModel.resumePossibleUnacknowledgedDipPurchases()
     }
 
     val showAllLocations = remember { mutableStateOf(false) }

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,11 +50,13 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SignupDedicatedIpScreen() = Screen {
-    val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        hasActivePlaystoreSubscription()
-        getDipSupportedCountries()
-        getDipMonthlyPlan()
-        getDipYearlyPlan()
+    val viewModel: DipViewModel = koinViewModel()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.hasActivePlaystoreSubscription()
+        viewModel.getDipSupportedCountries()
+        viewModel.getDipMonthlyPlan()
+        viewModel.getDipYearlyPlan()
     }
 
     Column(

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenActivateScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/SignupDedicatedIpTokenActivateScreen.kt
@@ -70,6 +70,7 @@ fun SignupDedicatedIpTokenActivateScreen() = Screen {
             Spacer(modifier = Modifier.height(16.dp))
             Input(
                 modifier = Modifier.fillMaxWidth(),
+                enabled = false,
                 maskInput = false,
                 keyboard = KeyboardType.Text,
                 content = dipToken,
@@ -114,7 +115,9 @@ fun SignupDedicatedIpTokenActivateScreen() = Screen {
                 .padding(horizontal = 16.dp),
         ) {
             showSpinner.value = true
-            viewModel.activateDedicatedIp(mutableStateOf(TextFieldValue(dipToken.value)))
+            viewModel.activateDedicatedIp(
+                mutableStateOf(TextFieldValue(viewModel.getSignupDipToken())),
+            )
         }
         Spacer(modifier = Modifier.height(64.dp))
     }


### PR DESCRIPTION
## Summary

It introduces the logic around resuming a DIP signup purchase that was not acknowledged due to an error confirming it with our backend.

## Sanity Tests
_**Using staging-3**_

- [x] Open the app. Purchase a VPN subscription. Go to DIP signup. Confirm we show the list of plans. (Mocking a failure on the signup validation). Try to purchase a DIP subscription. Confirm it fails due to the mocking but it's still added to the account Google subscription with an unconfirmed state.
- [x] After the above. (Remove the mocking of a failure). Go to DIP signup. Confirm it immediately goes to the loading screen to resume the purchase and confirm the purchase. Confirm it does so successfully and a token is shown to the user. (Can't confirm the activation as it doesn't work on staging-3).