### PR TITLE
PIA-1960: Fix OVPN DIP not connecting

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -161,7 +161,7 @@ object Dependencies {
     }
 
     fun DependencyHandler.implementVpnManager() {
-        add(IMPLEMENTATION, "com.kape.android:vpnmanager:0.3.7")
+        add(IMPLEMENTATION, "com.kape.android:vpnmanager:0.3.7-pia")
     }
 
     fun DependencyHandler.implementDrawablePainter() {

--- a/core/vpnconnect/src/main/java/com/kape/vpnconnect/domain/ConnectionUseCase.kt
+++ b/core/vpnconnect/src/main/java/com/kape/vpnconnect/domain/ConnectionUseCase.kt
@@ -294,6 +294,17 @@ class ConnectionUseCase(
             }
         }
 
+        val cipher = when (settingsPrefs.getOpenVpnSettings().dataEncryption) {
+            DataEncryption.AES_128_GCM -> "AES-128-GCM"
+            DataEncryption.AES_256_GCM -> "AES-256-GCM"
+            DataEncryption.CHA_CHA_20 -> "CHACHA20-POLY1305"
+        }
+
+        var additionalOpenVpnParams = "--cipher $cipher "
+        if (server.isDedicatedIp) {
+            additionalOpenVpnParams += "--ncp-disable --pia-signal-settings"
+        }
+
         notificationBuilder.setContentTitle("${server.name} - privateinternetaccess.com")
         notificationBuilder.setContentIntent(configureIntent)
 
@@ -335,6 +346,7 @@ class ConnectionUseCase(
                 username = username,
                 password = password,
                 socksProxy = getProxyDetails(),
+                additionalParameters = additionalOpenVpnParams,
             ),
             wireguardClientConfiguration = WireguardClientConfiguration(
                 token = connectionSource.getVpnToken(),


### PR DESCRIPTION
## Summary

It fixes an issue where attempting to connect to a DIP server while using openvpn was failing due to those servers relying on PSS (pia-signal-settings).

## Sanity Tests

- [x] On a regular VPN server. Connect to any region using Wireguard. Confirm it connects successfully.
- [x] On a regular VPN server. Connect to any region using OpenVPN TCP. Confirm it connects successfully.
- [x] On a regular VPN server. Connect to any region using OpenVPN UDP. Confirm it connects successfully.
- [x] On a DIP VPN server. Connect to any region using Wireguard. Confirm it connects successfully.
- [x] On a DIP VPN server. Connect to any region using OpenVPN TCP. Confirm it connects successfully.
- [x] On a DIP VPN server. Connect to any region using OpenVPN UDP. Confirm it connects successfully.