### PR TITLE
PIA-1951: Introduce loading state for the subscriptions screen

### DIFF
--- a/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
@@ -23,6 +23,7 @@ import com.kape.signup.utils.EMAIL
 import com.kape.signup.utils.ERROR_EMAIL_INVALID
 import com.kape.signup.utils.ERROR_REGISTRATION
 import com.kape.signup.utils.IN_PROCESS
+import com.kape.signup.utils.LOADING
 import com.kape.signup.utils.NO_IN_APP_SUBSCRIPTIONS
 import com.kape.signup.utils.Plan
 import com.kape.signup.utils.SUBSCRIPTIONS
@@ -160,7 +161,9 @@ class SignupViewModel(
 
     fun loadPrices() = viewModelScope.launch {
         if (subscriptionPrefs.getVpnSubscriptions().isEmpty()) {
+            _state.emit(LOADING)
             subscriptionsUseCase.getVpnSubscriptions().collect {
+                _state.emit(DEFAULT)
                 vpnSubscriptionPaymentProvider.loadProducts()
             }
         } else {


### PR DESCRIPTION
## Summary

As per title. It shows the loading state where the subscription details are being fetched.

## Sanity Tests

- [x] While in a slow network. Do a clean install. Open the application. Confirm the loading screen, followed by the screen with the populated plans.
- [x] After the above. Kill the process. Open the app. Confirm subscriptions is shown immediately as we are not fetching the plans always.