### PR TITLE
PIA-1973: Fix DIP signup activation crash

### DIFF
--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
@@ -67,13 +67,12 @@ import com.kape.ui.utils.getFlagResource
 import com.kape.utils.vpnserver.VpnServer
 import com.privateinternetaccess.regions.REGIONS_PING_TIMEOUT
 import org.koin.androidx.compose.koinViewModel
-import java.util.Locale
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun DedicatedIpScreen() = Screen {
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        loadDedicatedIps(Locale.getDefault().language)
+        loadDedicatedIps()
     }
     val appBarViewModel: AppBarViewModel = koinViewModel<AppBarViewModel>().apply {
         appBarText(stringResource(id = com.kape.ui.R.string.dedicated_ip_title))

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/tv/TvDedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/tv/TvDedicatedIpScreen.kt
@@ -54,12 +54,11 @@ import com.kape.vpnconnect.utils.ConnectionManager
 import com.kape.vpnconnect.utils.ConnectionStatus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
-import java.util.Locale
 
 @Composable
 fun TvDedicatedIpScreen() = Screen {
     val viewModel: DipViewModel = koinViewModel<DipViewModel>().apply {
-        loadDedicatedIps(Locale.getDefault().language)
+        loadDedicatedIps()
     }
     val connectionManager: ConnectionManager = koinInject()
     val connectionStatus = connectionManager.connectionStatus.collectAsState()

--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/vm/DipViewModel.kt
@@ -51,7 +51,6 @@ class DipViewModel(
     private val _state = MutableStateFlow<DedicatedIpStep?>(null)
     val state: StateFlow<DedicatedIpStep?> = _state
     val activateTokenButtonState = mutableStateOf(false)
-    private lateinit var userLocale: String
 
     val dipList = mutableStateListOf<VpnServer>()
     val activationState = mutableStateOf<DipApiResult?>(null)
@@ -113,8 +112,7 @@ class DipViewModel(
         observeScreenCaptureUseCase.registerCallback(callback)
     }
 
-    fun loadDedicatedIps(locale: String) = viewModelScope.launch {
-        userLocale = locale
+    fun loadDedicatedIps() = viewModelScope.launch {
         dipList.clear()
         for (dip in dipPrefs.getDedicatedIps()) {
             dipList.addAll(regionListProvider.servers.value.filter { it.isDedicatedIp })
@@ -128,7 +126,7 @@ class DipViewModel(
                 DipApiResult.Active -> {
                     dipToken.value = TextFieldValue("")
                     dipPrefs.removePurchasedSignupDipToken()
-                    loadDedicatedIps(userLocale)
+                    loadDedicatedIps()
                 }
 
                 DipApiResult.Expired -> {
@@ -153,7 +151,7 @@ class DipViewModel(
         for (dip in dipPrefs.getDedicatedIps()) {
             if (dip.dipToken == dipToken) {
                 dipPrefs.removeDedicatedIp(dip)
-                loadDedicatedIps(userLocale)
+                loadDedicatedIps()
             }
         }
     }


### PR DESCRIPTION
## Summary

We are crashing on activation due to the `lateinit` for the locale in the `viewmodel`. A variable we don't use anymore.

## Sanity Tests
**_Enabling DIP Signup_**

- [x] Install and open the app. Login. Subscribe to VPN. Go to the home screen. Purchase a DIP. Confirm it does so successfully and we end the flow with an activated DIP for the selected region.
- [x] Uninstall and the app. Login. Go to the Dedicated IP option. Activate an existing DIP token. Confirm it activates it successfully.