### PR TITLE
PIA-XXXX: Bump version to 4.0.10 (673)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,10 +24,10 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-val googleAppVersionCode = 672
+val googleAppVersionCode = 673
 val amazonAppVersionCode = googleAppVersionCode.plus(10000)
 val noInAppVersionCode = googleAppVersionCode.plus(10000)
-val appVersionName = "4.0.9"
+val appVersionName = "4.0.10"
 
 android {
     namespace = "com.kape.vpn"


### PR DESCRIPTION
## Summary

As per title. It bumps de version name and code to `4.0.10` and `673` respectively.

## Sanity Tests

- [x] Run the charter. Confirm it succeeds.