### PR TITLE
KM-5236: Hide the Subscribe Now button on TV Welcome Screen on non-Google builds

### DIFF
--- a/features/tvwelcome/build.gradle.kts
+++ b/features/tvwelcome/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     implementation(project(":core:router"))
     implementation(project(":core:payments"))
+    implementation(project(":capabilities:buildconfig"))
     implementation(project(":capabilities:ui"))
     implementation(project(":features:login"))
 

--- a/features/tvwelcome/src/main/java/com/kape/tvwelcome/di/TvWelcomeModule.kt
+++ b/features/tvwelcome/src/main/java/com/kape/tvwelcome/di/TvWelcomeModule.kt
@@ -5,5 +5,5 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val tvWelcomeModule = module {
-    viewModel { TvWelcomeViewModel(get()) }
+    viewModel { TvWelcomeViewModel(get(), get()) }
 }

--- a/features/tvwelcome/src/main/java/com/kape/tvwelcome/ui/TvWelcomeScreen.kt
+++ b/features/tvwelcome/src/main/java/com/kape/tvwelcome/ui/TvWelcomeScreen.kt
@@ -76,9 +76,11 @@ fun TvWelcomeScreen() = Screen {
             ) {
                 welcomeViewModel.login()
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            PrimaryButton(text = stringResource(id = R.string.subscribe_now)) {
-                welcomeViewModel.signup()
+            if (welcomeViewModel.shouldShowSubscribeButton) {
+                Spacer(modifier = Modifier.height(8.dp))
+                PrimaryButton(text = stringResource(id = R.string.subscribe_now)) {
+                    welcomeViewModel.signup()
+                }
             }
         }
         Spacer(modifier = Modifier.width(64.dp))

--- a/features/tvwelcome/src/main/java/com/kape/tvwelcome/ui/vm/TvWelcomeViewModel.kt
+++ b/features/tvwelcome/src/main/java/com/kape/tvwelcome/ui/vm/TvWelcomeViewModel.kt
@@ -2,6 +2,7 @@ package com.kape.tvwelcome.ui.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.router.EnterFlow
 import com.kape.router.Exit
 import com.kape.router.Router
@@ -10,7 +11,10 @@ import org.koin.core.component.KoinComponent
 
 class TvWelcomeViewModel(
     private val router: Router,
+    buildConfigProvider: BuildConfigProvider,
 ) : ViewModel(), KoinComponent {
+
+    val shouldShowSubscribeButton = buildConfigProvider.isGoogleFlavor()
 
     fun login() = viewModelScope.launch {
         router.handleFlow(EnterFlow.TvLoginUsername)


### PR DESCRIPTION
## Issue Link
https://polymoon.atlassian.net/browse/KM-5236

## Purpose
See title

## Sanity checks
Google build shows the "Subscribe Now" button
![google](https://github.com/user-attachments/assets/25878644-8474-4734-83d8-a74121ef7dfc)

Amazon build does not show the "Subscribe Now" button
![amazon](https://github.com/user-attachments/assets/f61d246c-a592-4b3d-bdd6-415995e3b353)
