### PR TITLE
KM-5242 - Hide login with purchase receipt button on non-Google builds

### DIFF
--- a/features/login/build.gradle.kts
+++ b/features/login/build.gradle.kts
@@ -57,10 +57,13 @@ dependencies {
     coreLibraryDesugaring(desugarJdkLibs)
 
     implementAccount()
+
     implementation(project(":core:payments"))
     implementation(project(":core:router"))
     implementation(project(":core:utils"))
     implementation(project(":core:vpnconnect"))
+
+    implementation(project(":capabilities:buildconfig"))
     implementation(project(":capabilities:ui"))
 
     // prefs

--- a/features/login/src/main/java/com/kape/login/di/LoginModule.kt
+++ b/features/login/src/main/java/com/kape/login/di/LoginModule.kt
@@ -45,6 +45,6 @@ private val localLoginModule = module {
     single { GetUserLoggedInUseCase(get()) }
     viewModel { LoginUsernameViewModel(get(), get()) }
     viewModel { LoginPasswordViewModel(get()) }
-    viewModel { LoginViewModel(get(), get(), get(), get(), get()) }
+    viewModel { LoginViewModel(get(), get(), get(), get(), get(), get()) }
     viewModel { LoginWithEmailViewModel(get(), get()) }
 }

--- a/features/login/src/main/java/com/kape/login/ui/mobile/LoginScreen.kt
+++ b/features/login/src/main/java/com/kape/login/ui/mobile/LoginScreen.kt
@@ -148,18 +148,20 @@ fun LoginScreen(navController: NavController) = Screen {
                 )
             }
 
-            Text(
-                text = stringResource(id = com.kape.ui.R.string.login_with_receipt).toUpperCase(
-                    Locale.current,
-                ),
-                color = LocalColors.current.primary,
-                modifier = Modifier
-                    .align(CenterHorizontally)
-                    .padding(16.dp, 16.dp, 16.dp, 8.dp)
-                    .clickable {
-                        viewModel.loginWithReceipt(currentContext.packageName)
-                    },
-            )
+            if (viewModel.shouldShowLoginWithReceiptButton) {
+                Text(
+                    text = stringResource(id = com.kape.ui.R.string.login_with_receipt).toUpperCase(
+                        Locale.current,
+                    ),
+                    color = LocalColors.current.primary,
+                    modifier = Modifier
+                        .align(CenterHorizontally)
+                        .padding(16.dp, 16.dp, 16.dp, 8.dp)
+                        .clickable {
+                            viewModel.loginWithReceipt(currentContext.packageName)
+                        },
+                )
+            }
             Text(
                 text = stringResource(id = com.kape.ui.R.string.login_with_magic_link).toUpperCase(
                     Locale.current,

--- a/features/login/src/main/java/com/kape/login/ui/vm/LoginViewModel.kt
+++ b/features/login/src/main/java/com/kape/login/ui/vm/LoginViewModel.kt
@@ -2,6 +2,7 @@ package com.kape.login.ui.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.login.domain.mobile.GetUserLoggedInUseCase
 import com.kape.login.domain.mobile.LoginUseCase
 import com.kape.login.utils.FAILED
@@ -26,12 +27,14 @@ class LoginViewModel(
     private val userLoggedInUseCase: GetUserLoggedInUseCase,
     private val vpnSubscriptionPaymentProvider: VpnSubscriptionPaymentProvider,
     private val router: Router,
+    private val buildConfigProvider: BuildConfigProvider,
     networkConnectionListener: NetworkConnectionListener,
 ) : ViewModel(), KoinComponent {
 
     private val _state = MutableStateFlow(IDLE)
     val loginState: StateFlow<LoginScreenState> = _state
     val isConnected = networkConnectionListener.isConnected
+    val shouldShowLoginWithReceiptButton: Boolean = buildConfigProvider.isGoogleFlavor()
 
     private lateinit var packageName: String
 


### PR DESCRIPTION
## Issue Link
https://polymoon.atlassian.net/browse/KM-5242

## Purpose
See title

## Sanity checks
- Verify that the "LOGIN USING PURCHASE RECEIPT" button is still displayed on the Google build
- Verify that the "LOGIN USING PURCHASE RECEIPT" button is hidden on the Amazon build
![pia_amazon_login](https://github.com/user-attachments/assets/07e101b9-8c79-4889-a572-3d205f8f1c2a)
