### PR TITLE
KM-5243 - Bugfix on SignUpScreen in Amazon build

### DIFF
--- a/features/signup/build.gradle.kts
+++ b/features/signup/build.gradle.kts
@@ -56,14 +56,18 @@ android {
 dependencies {
     coreLibraryDesugaring(desugarJdkLibs)
 
-    implementation(project(":core:router"))
     implementAccount()
-    implementation(project(":core:payments"))
-    implementation(project(":core:localprefs:signup"))
-    implementation(project(":core:localprefs:payments:data"))
-    implementation(project(":core:localprefs:payments"))
-    implementation(project(":core:utils"))
+
+    implementation(project(":capabilities:buildconfig"))
     implementation(project(":capabilities:ui"))
+
+    implementation(project(":core:localprefs:payments"))
+    implementation(project(":core:localprefs:payments:data"))
+    implementation(project(":core:localprefs:signup"))
+    implementation(project(":core:payments"))
+    implementation(project(":core:router"))
+    implementation(project(":core:utils"))
+
     implementation(project(":features:login"))
 
     implementFeatureModule()

--- a/features/signup/src/main/java/com/kape/signup/di/SignupModule.kt
+++ b/features/signup/src/main/java/com/kape/signup/di/SignupModule.kt
@@ -26,5 +26,5 @@ private val localSignupModule = module {
     single { PriceFormatter(get()) }
     single { ConsentPrefs(get()) }
     single { ConsentUseCase(get()) }
-    viewModel { SignupViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { SignupViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/vm/SignupViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kape.buildconfig.data.BuildConfigProvider
 import com.kape.login.domain.mobile.GetUserLoggedInUseCase
 import com.kape.payments.SubscriptionPrefs
 import com.kape.payments.domain.GetSubscriptionsUseCase
@@ -17,6 +18,7 @@ import com.kape.router.ExitFlow
 import com.kape.router.Router
 import com.kape.signup.domain.ConsentUseCase
 import com.kape.signup.domain.SignupUseCase
+import com.kape.signup.utils.AMAZON_LOGIN
 import com.kape.signup.utils.CONSENT
 import com.kape.signup.utils.DEFAULT
 import com.kape.signup.utils.EMAIL
@@ -48,6 +50,7 @@ class SignupViewModel(
     private val router: Router,
     private val subscriptionPrefs: SubscriptionPrefs,
     private val subscriptionsUseCase: GetSubscriptionsUseCase,
+    private val buildConfigProvider: BuildConfigProvider,
     networkConnectionListener: NetworkConnectionListener,
 ) : ViewModel(), KoinComponent {
 
@@ -166,6 +169,10 @@ class SignupViewModel(
     }
 
     fun loadPrices() = viewModelScope.launch {
+        if (buildConfigProvider.isAmazonFlavor()) {
+            _state.emit(AMAZON_LOGIN)
+            return@launch
+        }
         if (subscriptionPrefs.getVpnSubscriptions().isEmpty()) {
             _state.emit(LOADING)
             subscriptionsUseCase.getVpnSubscriptions().collect {

--- a/features/signup/src/main/java/com/kape/signup/utils/SignupScreenState.kt
+++ b/features/signup/src/main/java/com/kape/signup/utils/SignupScreenState.kt
@@ -30,6 +30,7 @@ val SUBSCRIPTIONS_FAILED_TO_LOAD = SignupScreenState(
     SignupStep.Subscriptions(supportsSubscription = true, displaySubscribeButton = false),
 )
 val NO_IN_APP_SUBSCRIPTIONS = SignupScreenState(loading = false, SignupStep.Subscriptions(false))
+val AMAZON_LOGIN = SignupScreenState(loading = false, SignupStep.Subscriptions(supportsSubscription = true, displaySubscribeButton = false))
 
 fun signedUp(credentials: Credentials) =
     SignupScreenState(loading = false, SignupStep.SignedUp(credentials))


### PR DESCRIPTION
## Issue Link
https://polymoon.atlassian.net/browse/KM-5243

## Purpose
Avoid loading products and hide the "Subscribe now" button on the Amazon variant

## Implementation Details
This fixes two bugs at the same time:
1) an initial delay of ~30 seconds when launching the app
2) an empty screen after logging out
Both are caused by the loadPrices() function being triggered.
The cleaner solution would be not navigating to this screen at all, however this would require larger changes.

## Bug (demo video)

https://github.com/user-attachments/assets/ee4922af-7236-4b7a-ba06-b191c401161b


## Bugfix (demo video)

https://github.com/user-attachments/assets/ea3f7c24-49a4-41b6-b8d4-1436a35e1aa5

