### PR TITLE
KM-10765: Update VPNManager dependency

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -156,7 +156,7 @@ object Dependencies {
     }
 
     fun DependencyHandler.implementVpnManager() {
-        add(IMPLEMENTATION, "com.kape.android:vpnmanager:0.3.8-pia")
+        add(IMPLEMENTATION, "com.kape.android:vpnmanager:0.4.0-pia")
     }
 
     fun DependencyHandler.implementDrawablePainter() {


### PR DESCRIPTION
## Summary

As per the title. It updates the vpnmanager to version `0.4.0-pia`.

## Sanity Tests

- [x] Open app. Connect to any region. Confirm valid connection after ~4hrs.
- [x] After the above. Enable flight mode. Wait ~2hrs. Disable light mode. Confirm successfull reconnection.
- [x] Using DIP and the default settings. Connect to it. Confirm it connects successfully.  