### PR TITLE
KM-10767: Update default DNS to match the Desktop / iOS clients

### DIFF
--- a/core/vpnconnect/src/main/java/com/kape/vpnconnect/domain/ConnectionUseCase.kt
+++ b/core/vpnconnect/src/main/java/com/kape/vpnconnect/domain/ConnectionUseCase.kt
@@ -38,7 +38,7 @@ import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 
 private const val MACE_DNS = "10.0.0.241"
-private const val PIA_DNS = "10.0.0.242"
+private const val PIA_DNS = "10.0.0.243"
 
 class ConnectionUseCase(
     private val connectionSource: ConnectionDataSource,


### PR DESCRIPTION
## Summary

As per the title. It updates the default DNS address to match Desktop and iOS clients.

## Sanity Tests

- [x] Connect to test server. Confirm resolver address.