### PR TITLE
KM-11399: Bump version to 4.0.22

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
     alias(libs.plugins.configuration)
 }
 
-val googleAppVersionCode = 685
+val googleAppVersionCode = 686
 val amazonAppVersionCode = googleAppVersionCode.plus(10000)
 val noInAppVersionCode = googleAppVersionCode.plus(10000)
-val appVersionName = "4.0.21"
+val appVersionName = "4.0.22"
 
 android {
     namespace = "com.kape.vpn"


### PR DESCRIPTION
## Summary

As per title. It bumps de version name and code to `4.0.22` and `686` respectively.

## Sanity Tests

- [x] Run the charter. Confirm it succeeds.