### PR TITLE
KM-15104: Ellipsize DIP server name on smaller screens

### DIFF
--- a/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
+++ b/features/dedicatedip/src/main/java/com/kape/dedicatedip/ui/screens/mobile/DedicatedIpScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import com.kape.appbar.view.mobile.AppBar
 import com.kape.appbar.viewmodel.AppBarViewModel
 import com.kape.dedicatedip.R
@@ -296,11 +297,15 @@ fun DipItem(
         Text(
             text = server.name,
             fontSize = 14.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .constrainAs(name) {
                     start.linkTo(icon.end, margin = 8.dp)
+                    end.linkTo(latency.start, margin = 8.dp)
                     top.linkTo(parent.top)
                     bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
                 }
                 .testTag(":DedicatedIPScreen:dip_server_name"),
         )


### PR DESCRIPTION
<img width="720" height="1280" alt="Screenshot_20260330_134328" src="https://github.com/user-attachments/assets/0ee1f2a7-b4ee-46bf-87e2-92f9dcbecac1" />
<img width="1080" height="2220" alt="Screenshot_20260330_134626" src="https://github.com/user-attachments/assets/1b4e7281-f430-4b32-b923-f048a071977b" />
