### PR TITLE
KM-17631: new paywall content fixes

### DIFF
--- a/capabilities/ui/src/main/java/com/kape/ui/utils/PriceFormatter.kt
+++ b/capabilities/ui/src/main/java/com/kape/ui/utils/PriceFormatter.kt
@@ -13,19 +13,6 @@ private const val MICROS_PER_UNIT = 1_000_000.0
 class PriceFormatter(
     private val context: Context,
 ) {
-    fun formatYearlyPlan(
-        cost: String,
-        slashVersion: Boolean = false,
-    ): String =
-        context
-            .getString(
-                if (slashVersion) {
-                    com.kape.ui.R.string.year_ending
-                } else {
-                    com.kape.ui.R.string.yearly_ending
-                },
-            ).format(cost)
-
     fun formatYearlyPerMonth(
         priceInMicros: Long,
         currencyCode: String,
@@ -36,8 +23,6 @@ class PriceFormatter(
             .getString(com.kape.ui.R.string.yearly_month_ending)
             .format(formatPrice(costPerMonth, currencyCode, originalFormattedPrice))
     }
-
-    fun formatMonthlyPlan(cost: String): String = context.getString(com.kape.ui.R.string.monthly_ending).format(cost)
 
     @VisibleForTesting
     private fun formatPrice(

--- a/features/dedicatedip/src/google/java/com/kape/dedicatedip/di/DipPurchaseModule.kt
+++ b/features/dedicatedip/src/google/java/com/kape/dedicatedip/di/DipPurchaseModule.kt
@@ -74,8 +74,7 @@ class DipPurchaseModule {
     fun provideGetDipMonthlyPlan(
         dipSignupRepository: DipSignupRepository,
         dipSubscriptionPaymentProvider: DipSubscriptionPaymentProvider,
-        formatter: PriceFormatter,
-    ): GetDipMonthlyPlan = GetDipMonthlyPlan(dipSignupRepository, dipSubscriptionPaymentProvider, formatter)
+    ): GetDipMonthlyPlan = GetDipMonthlyPlan(dipSignupRepository, dipSubscriptionPaymentProvider)
 
     @Singleton
     fun provideGetDipYearlyPlan(

--- a/features/dedicatedip/src/google/java/com/kape/dedicatedip/domain/GetDipMonthlyPlan.kt
+++ b/features/dedicatedip/src/google/java/com/kape/dedicatedip/domain/GetDipMonthlyPlan.kt
@@ -4,7 +4,6 @@ import com.kape.dedicatedip.data.DipSignupRepository
 import com.kape.dedicatedip.data.models.DedicatedIpMonthlyPlan
 import com.kape.payments.ui.DipSubscriptionPaymentProvider
 import com.kape.payments.utils.MONTHLY_SUBSCRIPTION
-import com.kape.ui.utils.PriceFormatter
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.annotation.Singleton
 import kotlin.coroutines.resume
@@ -13,7 +12,6 @@ import kotlin.coroutines.resume
 class GetDipMonthlyPlan(
     private val dipSignupRepository: DipSignupRepository,
     private val dipSubscriptionPaymentProvider: DipSubscriptionPaymentProvider,
-    private val formatter: PriceFormatter,
 ) {
     suspend operator fun invoke(): DedicatedIpMonthlyPlan? {
         val subscriptions = dipSignupRepository.signupPlans() ?: return null
@@ -33,7 +31,7 @@ class GetDipMonthlyPlan(
                         cont.resume(
                             DedicatedIpMonthlyPlan(
                                 id = productDetails.first,
-                                monthlyPrice = formatter.formatYearlyPlan(productDetails.second),
+                                monthlyPrice = productDetails.second,
                             ),
                         )
                     },

--- a/features/dedicatedip/src/google/java/com/kape/dedicatedip/domain/GetDipYearlyPlan.kt
+++ b/features/dedicatedip/src/google/java/com/kape/dedicatedip/domain/GetDipYearlyPlan.kt
@@ -33,7 +33,7 @@ class GetDipYearlyPlan(
                         cont.resume(
                             DedicatedIpYearlyPlan(
                                 id = productDetails.first,
-                                yearlyPrice = formatter.formatYearlyPlan(productDetails.second),
+                                yearlyPrice = productDetails.second,
                                 // 0L added to match formatYearlyPerMonth signature. To be fixed when dip goes live.
                                 monthlyPrice = formatter.formatYearlyPerMonth(0L, productDetails.second, "USD"),
                             ),

--- a/features/signup/src/google/java/com/kape/signup/data/GoogleSignupBillingHandler.kt
+++ b/features/signup/src/google/java/com/kape/signup/data/GoogleSignupBillingHandler.kt
@@ -19,7 +19,6 @@ import com.kape.signup.utils.SUBSCRIPTIONS_FAILED_TO_LOAD
 import com.kape.signup.utils.SignupScreenState
 import com.kape.signup.utils.SubscriptionData
 import com.kape.ui.utils.PriceFormatter
-import com.kape.utils.PlatformUtils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -34,7 +33,6 @@ class GoogleSignupBillingHandler(
     private val subscriptionPrefs: SubscriptionPrefs,
     private val subscriptionsUseCase: GetSubscriptionsUseCase,
     private val formatter: PriceFormatter,
-    private val platformUtils: PlatformUtils,
     private val submitEventUseCase: SubmitKpiEventUseCase,
 ) : SignupBillingHandler {
     private val _billingState = MutableSharedFlow<SignupScreenState>(replay = 1)
@@ -75,11 +73,7 @@ class GoogleSignupBillingHandler(
                                             }
                                         },
                                         hasFreeTrial = yearlyPlan.freeTrialDuration?.isNotBlank() ?: false,
-                                        mainPrice =
-                                            formatter.formatYearlyPlan(
-                                                cost = yearlyPlan.formattedPrice,
-                                                slashVersion = !platformUtils.isTv(),
-                                            ),
+                                        mainPrice = yearlyPlan.formattedPrice,
                                         secondaryPrice =
                                             formatter.formatYearlyPerMonth(
                                                 yearlyPlan.priceInMicros,
@@ -98,7 +92,7 @@ class GoogleSignupBillingHandler(
                                             }
                                         },
                                         false,
-                                        mainPrice = formatter.formatMonthlyPlan(monthlyPlan.formattedPrice),
+                                        mainPrice = monthlyPlan.formattedPrice,
                                     )
                                 val data =
                                     withContext(mainDispatcher) {

--- a/features/signup/src/google/java/com/kape/signup/di/SignupBillingModule.kt
+++ b/features/signup/src/google/java/com/kape/signup/di/SignupBillingModule.kt
@@ -16,7 +16,6 @@ import com.kape.signup.domain.SignupDataSource
 import com.kape.signup.domain.SignupHandler
 import com.kape.signup.domain.SignupUseCase
 import com.kape.ui.utils.PriceFormatter
-import com.kape.utils.PlatformUtils
 import com.privateinternetaccess.account.AndroidAccountAPI
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Singleton
@@ -32,7 +31,6 @@ class SignupBillingModule {
         subscriptionPrefs: SubscriptionPrefs,
         subscriptionsUseCase: GetSubscriptionsUseCase,
         formatter: PriceFormatter,
-        platformUtils: PlatformUtils,
         submitEventUseCase: SubmitKpiEventUseCase,
     ): SignupBillingHandler =
         GoogleSignupBillingHandler(
@@ -40,7 +38,6 @@ class SignupBillingModule {
             subscriptionPrefs,
             subscriptionsUseCase,
             formatter,
-            platformUtils,
             submitEventUseCase,
         )
 

--- a/features/signup/src/main/java/com/kape/signup/ui/mobile/NewPaywallSignUpScreen.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/mobile/NewPaywallSignUpScreen.kt
@@ -339,7 +339,7 @@ private fun ColumnScope.PlansPresentContent(
                     stringResource(id = R.string.subscription_option)
                 YearlySubscriptionCard(
                     selected = selectedPlan == subscriptionData.yearly,
-                    price = subscriptionData.yearly.mainPrice,
+                    price = stringResource(R.string.year_ending, subscriptionData.yearly.mainPrice),
                     additionalText = stringResource(R.string.subscribe_screen_billed_annually),
                     selectedCardColor = Color.Transparent,
                     bestValueBannerText = stringResource(R.string.subscribe_screen_best_value),
@@ -353,7 +353,7 @@ private fun ColumnScope.PlansPresentContent(
                 Spacer(modifier = Modifier.height(16.dp))
                 MonthlySubscriptionCard(
                     selected = selectedPlan == subscriptionData.monthly,
-                    price = subscriptionData.monthly.mainPrice,
+                    price = stringResource(R.string.monthly_ending, subscriptionData.monthly.mainPrice),
                     additionalText = stringResource(R.string.subscribe_screen_billed_monthly),
                     selectedCardColor = Color.Transparent,
                     modifier =

--- a/features/signup/src/main/java/com/kape/signup/ui/mobile/SignUpScreen.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/mobile/SignUpScreen.kt
@@ -137,7 +137,7 @@ fun OldSignUpScreen() {
                         } else {
                             "${
                                 stringResource(id = R.string.subscribe_screen_description).format(
-                                    subscriptionData?.yearly?.mainPrice,
+                                    "${subscriptionData?.yearly?.mainPrice} ${stringResource(R.string.subscribe_screen_per_year_ending)}",
                                 )
                             } ${stringResource(id = R.string.subscribe_screen_description_cancel_anytime)}"
                         },
@@ -151,7 +151,7 @@ fun OldSignUpScreen() {
                     val subscriptionOptions = stringResource(id = R.string.subscription_option)
                     YearlySubscriptionCard(
                         selected = subscriptionData?.selected?.value == subscriptionData?.yearly,
-                        price = subscriptionData?.yearly?.mainPrice ?: "",
+                        price = stringResource(R.string.yearly_ending, subscriptionData?.yearly?.mainPrice ?: ""),
                         additionalText = subscriptionData?.yearly?.secondaryPrice ?: "",
                         modifier =
                             Modifier
@@ -166,7 +166,7 @@ fun OldSignUpScreen() {
                     Spacer(modifier = Modifier.height(16.dp))
                     MonthlySubscriptionCard(
                         selected = subscriptionData?.selected?.value == subscriptionData?.monthly,
-                        price = subscriptionData?.monthly?.mainPrice ?: "",
+                        price = stringResource(R.string.monthly_ending, subscriptionData?.monthly?.mainPrice ?: ""),
                         modifier =
                             Modifier
                                 .fillMaxWidth()

--- a/features/signup/src/main/java/com/kape/signup/ui/shared/SharedSignUpComponents.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/shared/SharedSignUpComponents.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.kape.signup.utils.Plan
@@ -72,8 +74,12 @@ internal fun SubscriptionDescriptionText(
                 } else {
                     withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
                         append(
-                            stringResource(R.string.subscribe_screen_trial_monthly_description_headline)
-                                .format(subscriptionData.monthly.mainPrice),
+                            "${subscriptionData.monthly.mainPrice} " +
+                                "${stringResource(R.string.subscribe_screen_per_month_ending)}, " +
+                                "${
+                                    stringResource(R.string.subscribe_screen_billed_monthly)
+                                        .toLowerCase(Locale.current)
+                                }.",
                         )
                     }
                     append(" ${stringResource(id = R.string.subscribe_screen_trial_monthly_description)}")

--- a/features/signup/src/main/java/com/kape/signup/ui/tv/NewPaywallTvSignUpScreen.kt
+++ b/features/signup/src/main/java/com/kape/signup/ui/tv/NewPaywallTvSignUpScreen.kt
@@ -185,7 +185,7 @@ fun NewPaywallTvSignUpScreen() {
                 text =
                     buildAnnotatedString {
                         val template = stringResource(id = R.string.tv_subscribe_screen_description)
-                        val price = subscriptionData?.yearly?.mainPrice ?: ""
+                        val price = subscriptionData?.yearly?.mainPrice?.let { stringResource(R.string.yearly_ending, it) } ?: ""
                         val placeholderIndex = template.indexOf("%s")
                         if (placeholderIndex >= 0) {
                             append(template.substring(0, placeholderIndex))
@@ -203,7 +203,7 @@ fun NewPaywallTvSignUpScreen() {
             Spacer(modifier = Modifier.weight(1f))
             YearlySubscriptionCard(
                 selected = subscriptionData?.selected?.value == subscriptionData?.yearly,
-                price = subscriptionData?.yearly?.mainPrice ?: "",
+                price = stringResource(R.string.yearly_ending, subscriptionData?.yearly?.mainPrice ?: ""),
                 perMonthPrice = subscriptionData?.yearly?.secondaryPrice ?: "",
                 modifier =
                     Modifier
@@ -218,7 +218,10 @@ fun NewPaywallTvSignUpScreen() {
             Spacer(modifier = Modifier.height(16.dp))
             MonthlySubscriptionCard(
                 selected = subscriptionData?.selected?.value == subscriptionData?.monthly,
-                price = subscriptionData?.monthly?.mainPrice ?: "",
+                price =
+                    subscriptionData?.monthly?.mainPrice?.let {
+                        "$it ${stringResource(R.string.subscribe_screen_per_month_ending)}"
+                    } ?: "",
                 modifier =
                     Modifier
                         .padding(horizontal = 20.dp)


### PR DESCRIPTION
I've decided to move away from adding a "per year" or similar suffix when formatting the price, because the suffix is different for new TV, new mobile, and old paywall. Now, the suffix is added by the appropriate UI component.