### PR TITLE
Potential fix for unble to connect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!--Keeps the OpenVPN subprocess from being frozen by Doze/App Standby while connected,
+        which was causing it to miss ping-restart windows and reconnect on a ~60s loop-->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!--Android 13-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!--Android 14-->

--- a/core/vpnconnect/src/main/java/com/kape/vpnconnect/platformsdk/PiaService.kt
+++ b/core/vpnconnect/src/main/java/com/kape/vpnconnect/platformsdk/PiaService.kt
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import com.kape.contracts.ConfigInfo
 import com.kape.contracts.ConnectionInfoProvider
 import com.kape.contracts.ConnectionManager
@@ -71,6 +73,13 @@ class PiaService :
     private val kpiDataSource: KpiDataSource by inject()
     private var sessionController: KapeSessionController? = null
     private var statusCollectionJob: Job? = null
+
+    // Held only while a session is connecting/connected so the OS doesn't freeze this process
+    // during Doze/App Standby and cause it to miss the OpenVPN ping-restart window.
+    private val wakeLock: PowerManager.WakeLock by lazy {
+        (getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "$packageName:vpnConnection")
+    }
 
     private val _connectionStatus = MutableStateFlow(KapeVPNConnectionStatus.Disconnected)
     val connectionStatus: StateFlow<KapeVPNConnectionStatus> = _connectionStatus.asStateFlow()
@@ -135,6 +144,8 @@ class PiaService :
         sessionController = null
         statusCollectionJob?.cancel()
         statusCollectionJob = null
+
+        if (!wakeLock.isHeld) wakeLock.acquire()
 
         notificationHandler.updateConnectionInfo(
             getString(
@@ -240,6 +251,7 @@ class PiaService :
         sessionController = null
         usageProvider.reset()
         _connectionStatus.update { KapeVPNConnectionStatus.Disconnected }
+        if (wakeLock.isHeld) wakeLock.release()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Root cause:
  - The real symptom was the tunnel cycling on ping-restart roughly every 60–90s. Log timestamps showed the OpenVPN subprocess stalling ~62s and ~19s right at spawn on two of six restarts — the
    process/thread getting suspended by the OS, not the binary being slow.
  - Neither mobile-android nor the vpnmanager library ever held a PowerManager wake lock, so nothing protected the connection from being frozen by Doze/App Standby (or OEM battery managers) while idle —
    long enough to blow past the 60s ping-restart ceiling and force a reconnect.

  Fix applied in core/vpnconnect/.../PiaService.kt: acquire a PARTIAL_WAKE_LOCK when a session starts (startVpn), release it on every disconnect path (stopSessionController, which onDestroy/onRevoke
  already funnel through). Added the WAKE_LOCK permission explicitly in app/src/main/AndroidManifest.xml rather than relying on it being pulled in transitively.